### PR TITLE
Refactor gate logic: separate core decision from discord.js

### DIFF
--- a/src/adapters/discord/access.ts
+++ b/src/adapters/discord/access.ts
@@ -1,9 +1,9 @@
-import { readFileSync, writeFileSync, readdirSync, rmSync, mkdirSync } from 'node:fs'
+import { readFileSync, writeFileSync, readdirSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
-import { randomBytes } from 'node:crypto'
 import { ACCESS_FILE, APPROVED_DIR } from '../../core/config.js'
 import type { Access, GateResult } from '../../core/types.js'
 import { DEFAULT_ACCESS } from '../../core/types.js'
+import { evaluateGate } from '../../core/gate.js'
 import type { Client, Message } from 'discord.js'
 import { ChannelType } from 'discord.js'
 
@@ -40,55 +40,27 @@ export async function gate(
   const access = readAccessFile()
   pruneExpired(access)
 
-  const senderId = msg.author.id
   const isDM = msg.channel.type === ChannelType.DM
+  const isThread = !isDM && msg.channel.isThread()
 
-  if (isDM) {
-    if (access.dmPolicy === 'disabled') return { action: 'drop' }
-    if (access.allowFrom.includes(senderId)) return { action: 'deliver', access }
-    if (access.dmPolicy === 'allowlist') return { action: 'drop' }
+  // Resolve mention before calling pure gate logic (guild messages only)
+  const mentioned = !isDM && await isMentioned(msg, client, recentSentIds, access.mentionPatterns)
 
-    // Pairing mode — check existing pending code for this sender
-    for (const [code, p] of Object.entries(access.pending)) {
-      if (p.senderId === senderId) {
-        if ((p.replies ?? 1) >= 2) return { action: 'drop' }
-        p.replies = (p.replies ?? 1) + 1
-        saveAccess(access)
-        return { action: 'pair', code, isResend: true }
-      }
-    }
-    if (Object.keys(access.pending).length >= 3) return { action: 'drop' }
+  const result = evaluateGate({
+    senderId: msg.author.id,
+    channelId: msg.channelId,
+    isDM,
+    isThread,
+    parentChannelId: isThread ? (msg.channel.parentId ?? undefined) : undefined,
+    isMentioned: mentioned,
+  }, access)
 
-    const code = randomBytes(3).toString('hex')
-    const now = Date.now()
-    access.pending[code] = {
-      senderId,
-      chatId: msg.channelId,
-      createdAt: now,
-      expiresAt: now + 60 * 60 * 1000,
-      replies: 1,
-    }
+  // Persist access changes from pairing
+  if (result.action === 'pair') {
     saveAccess(access)
-    return { action: 'pair', code, isResend: false }
   }
 
-  // Guild message
-  const channelId = msg.channel.isThread()
-    ? msg.channel.parentId ?? msg.channelId
-    : msg.channelId
-  const policy = access.groups[channelId]
-  if (!policy) return { action: 'drop' }
-
-  const groupAllowFrom = policy.allowFrom ?? []
-  const requireMention = policy.requireMention ?? true
-
-  if (groupAllowFrom.length > 0 && !groupAllowFrom.includes(senderId)) {
-    return { action: 'drop' }
-  }
-  if (requireMention && !(await isMentioned(msg, client, recentSentIds, access.mentionPatterns))) {
-    return { action: 'drop' }
-  }
-  return { action: 'deliver', access }
+  return result
 }
 
 export async function isMentioned(

--- a/src/core/gate.ts
+++ b/src/core/gate.ts
@@ -1,0 +1,65 @@
+import { randomBytes } from 'node:crypto'
+import type { Access, GateResult } from './types.js'
+
+export type GateInput = {
+  senderId: string
+  channelId: string
+  isDM: boolean
+  isThread: boolean
+  parentChannelId?: string
+  isMentioned: boolean
+}
+
+/**
+ * Pure gate logic: decides whether to deliver, drop, or pair based on
+ * access policy and message metadata. No platform-specific dependencies.
+ *
+ * NOTE: when the result is 'pair', the caller is responsible for persisting
+ * the updated access object (it mutates access.pending in place).
+ */
+export function evaluateGate(input: GateInput, access: Access): GateResult {
+  const { senderId, channelId, isDM, isThread, parentChannelId, isMentioned } = input
+
+  if (isDM) {
+    if (access.dmPolicy === 'disabled') return { action: 'drop' }
+    if (access.allowFrom.includes(senderId)) return { action: 'deliver', access }
+    if (access.dmPolicy === 'allowlist') return { action: 'drop' }
+
+    // Pairing mode: check existing pending code for this sender
+    for (const [code, p] of Object.entries(access.pending)) {
+      if (p.senderId === senderId) {
+        if ((p.replies ?? 1) >= 2) return { action: 'drop' }
+        p.replies = (p.replies ?? 1) + 1
+        return { action: 'pair', code, isResend: true }
+      }
+    }
+    if (Object.keys(access.pending).length >= 3) return { action: 'drop' }
+
+    const code = randomBytes(3).toString('hex')
+    const now = Date.now()
+    access.pending[code] = {
+      senderId,
+      chatId: channelId,
+      createdAt: now,
+      expiresAt: now + 60 * 60 * 1000,
+      replies: 1,
+    }
+    return { action: 'pair', code, isResend: false }
+  }
+
+  // Guild message
+  const gateChannelId = isThread ? (parentChannelId ?? channelId) : channelId
+  const policy = access.groups[gateChannelId]
+  if (!policy) return { action: 'drop' }
+
+  const groupAllowFrom = policy.allowFrom ?? []
+  const requireMention = policy.requireMention ?? true
+
+  if (groupAllowFrom.length > 0 && !groupAllowFrom.includes(senderId)) {
+    return { action: 'drop' }
+  }
+  if (requireMention && !isMentioned) {
+    return { action: 'drop' }
+  }
+  return { action: 'deliver', access }
+}

--- a/tests/gate.test.ts
+++ b/tests/gate.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest'
+import { evaluateGate, type GateInput } from '../src/core/gate.js'
+import type { Access } from '../src/core/types.js'
+
+function makeAccess(overrides: Partial<Access> = {}): Access {
+  return {
+    dmPolicy: 'pairing',
+    allowFrom: [],
+    groups: {},
+    pending: {},
+    ...overrides,
+  }
+}
+
+function makeInput(overrides: Partial<GateInput> = {}): GateInput {
+  return {
+    senderId: 'user-1',
+    channelId: 'ch-1',
+    isDM: false,
+    isThread: false,
+    isMentioned: false,
+    ...overrides,
+  }
+}
+
+describe('evaluateGate() DM', () => {
+  it('delivers to allowlisted sender', () => {
+    const access = makeAccess({ allowFrom: ['user-1'] })
+    const result = evaluateGate(makeInput({ isDM: true }), access)
+    expect(result.action).toBe('deliver')
+  })
+
+  it('drops when dmPolicy is disabled', () => {
+    const access = makeAccess({ dmPolicy: 'disabled' })
+    const result = evaluateGate(makeInput({ isDM: true }), access)
+    expect(result.action).toBe('drop')
+  })
+
+  it('drops unknown sender when dmPolicy is allowlist', () => {
+    const access = makeAccess({ dmPolicy: 'allowlist' })
+    const result = evaluateGate(makeInput({ isDM: true }), access)
+    expect(result.action).toBe('drop')
+  })
+
+  it('creates pairing code for unknown sender in pairing mode', () => {
+    const access = makeAccess()
+    const result = evaluateGate(makeInput({ isDM: true }), access)
+    expect(result.action).toBe('pair')
+    if (result.action === 'pair') {
+      expect(result.isResend).toBe(false)
+      expect(result.code).toHaveLength(6)
+    }
+    // access.pending should be mutated
+    expect(Object.keys(access.pending)).toHaveLength(1)
+  })
+
+  it('resends existing code for same sender', () => {
+    const access = makeAccess({
+      pending: {
+        abc123: {
+          senderId: 'user-1',
+          chatId: 'ch-1',
+          createdAt: Date.now(),
+          expiresAt: Date.now() + 3600000,
+          replies: 1,
+        },
+      },
+    })
+    const result = evaluateGate(makeInput({ isDM: true }), access)
+    expect(result.action).toBe('pair')
+    if (result.action === 'pair') {
+      expect(result.code).toBe('abc123')
+      expect(result.isResend).toBe(true)
+    }
+    expect(access.pending.abc123.replies).toBe(2)
+  })
+
+  it('drops when sender has already received 2 replies', () => {
+    const access = makeAccess({
+      pending: {
+        abc123: {
+          senderId: 'user-1',
+          chatId: 'ch-1',
+          createdAt: Date.now(),
+          expiresAt: Date.now() + 3600000,
+          replies: 2,
+        },
+      },
+    })
+    const result = evaluateGate(makeInput({ isDM: true }), access)
+    expect(result.action).toBe('drop')
+  })
+
+  it('drops when 3 pending codes already exist', () => {
+    const access = makeAccess({
+      pending: {
+        aaa: { senderId: 'other-1', chatId: 'c', createdAt: 0, expiresAt: Date.now() + 3600000, replies: 1 },
+        bbb: { senderId: 'other-2', chatId: 'c', createdAt: 0, expiresAt: Date.now() + 3600000, replies: 1 },
+        ccc: { senderId: 'other-3', chatId: 'c', createdAt: 0, expiresAt: Date.now() + 3600000, replies: 1 },
+      },
+    })
+    const result = evaluateGate(makeInput({ isDM: true }), access)
+    expect(result.action).toBe('drop')
+  })
+})
+
+describe('evaluateGate() guild', () => {
+  it('drops when channel is not in groups', () => {
+    const access = makeAccess()
+    const result = evaluateGate(makeInput({ channelId: 'ch-unknown' }), access)
+    expect(result.action).toBe('drop')
+  })
+
+  it('delivers when channel is in groups and no restrictions', () => {
+    const access = makeAccess({
+      groups: { 'ch-1': { requireMention: false, allowFrom: [] } },
+    })
+    const result = evaluateGate(makeInput(), access)
+    expect(result.action).toBe('deliver')
+  })
+
+  it('drops when sender not in group allowFrom', () => {
+    const access = makeAccess({
+      groups: { 'ch-1': { requireMention: false, allowFrom: ['other-user'] } },
+    })
+    const result = evaluateGate(makeInput(), access)
+    expect(result.action).toBe('drop')
+  })
+
+  it('delivers when sender is in group allowFrom', () => {
+    const access = makeAccess({
+      groups: { 'ch-1': { requireMention: false, allowFrom: ['user-1'] } },
+    })
+    const result = evaluateGate(makeInput(), access)
+    expect(result.action).toBe('deliver')
+  })
+
+  it('drops when mention required but not mentioned', () => {
+    const access = makeAccess({
+      groups: { 'ch-1': { requireMention: true, allowFrom: [] } },
+    })
+    const result = evaluateGate(makeInput({ isMentioned: false }), access)
+    expect(result.action).toBe('drop')
+  })
+
+  it('delivers when mention required and mentioned', () => {
+    const access = makeAccess({
+      groups: { 'ch-1': { requireMention: true, allowFrom: [] } },
+    })
+    const result = evaluateGate(makeInput({ isMentioned: true }), access)
+    expect(result.action).toBe('deliver')
+  })
+
+  it('uses parent channel ID for thread messages', () => {
+    const access = makeAccess({
+      groups: { 'parent-ch': { requireMention: false, allowFrom: [] } },
+    })
+    const result = evaluateGate(makeInput({
+      channelId: 'thread-ch',
+      isThread: true,
+      parentChannelId: 'parent-ch',
+    }), access)
+    expect(result.action).toBe('deliver')
+  })
+
+  it('falls back to thread channel ID when parent is missing', () => {
+    const access = makeAccess({
+      groups: { 'thread-ch': { requireMention: false, allowFrom: [] } },
+    })
+    const result = evaluateGate(makeInput({
+      channelId: 'thread-ch',
+      isThread: true,
+      parentChannelId: undefined,
+    }), access)
+    expect(result.action).toBe('deliver')
+  })
+})


### PR DESCRIPTION
Closes #20

## Summary
- Extract pure gate decision logic into `src/core/gate.ts` with `GateInput` plain type
- Discord adapter resolves mention + extracts fields, then delegates to `evaluateGate()`
- 15 new tests for core gate logic, no discord.js mocking needed

## Changes
- **New** `src/core/gate.ts`: `evaluateGate(input, access)`, `GateInput` type
- **Modified** `src/adapters/discord/access.ts`: `gate()` now wraps `evaluateGate()`
- **New** `tests/gate.test.ts`: DM pairing (allow, pair, resend, reply cap, pending cap), guild (group check, allowFrom, mention, threads)

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (59/59)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)