### PR TITLE
Apply Biome lint/format fixes and enforce in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint
       - run: pnpm run build
       - run: pnpm run typecheck
       - run: pnpm test

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,12 +13,20 @@
     "url": "https://github.com/HealGaren/claude-channel-mux.git",
     "directory": "packages/cli"
   },
-  "keywords": ["claude", "claude-code", "cli"],
-  "engines": { "node": ">=20" },
+  "keywords": [
+    "claude",
+    "claude-code",
+    "cli"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
   "bin": {
     "channel-mux": "./dist/cli.mjs"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,6 @@
-import { readFileSync, existsSync, unlinkSync, openSync, closeSync, mkdirSync } from 'node:fs'
+import { execSync, spawn } from 'node:child_process'
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, unlinkSync } from 'node:fs'
 import { join } from 'node:path'
-import { spawn, execSync } from 'node:child_process'
 import { PID_FILE, SOCK_PATH, STATE_DIR } from '@claude-channel-mux/core'
 
 function isProcessAlive(pid: number): boolean {
@@ -15,15 +15,19 @@ function isProcessAlive(pid: number): boolean {
 function readPid(): number | null {
   try {
     const pid = parseInt(readFileSync(PID_FILE, 'utf8').trim(), 10)
-    return isNaN(pid) ? null : pid
+    return Number.isNaN(pid) ? null : pid
   } catch {
     return null
   }
 }
 
 function cleanupStateFiles(): void {
-  try { unlinkSync(PID_FILE) } catch {}
-  try { unlinkSync(SOCK_PATH) } catch {}
+  try {
+    unlinkSync(PID_FILE)
+  } catch {}
+  try {
+    unlinkSync(SOCK_PATH)
+  } catch {}
 }
 
 /**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,15 +13,24 @@
     "url": "https://github.com/HealGaren/claude-channel-mux.git",
     "directory": "packages/core"
   },
-  "keywords": ["claude", "claude-code", "mcp", "ipc"],
-  "engines": { "node": ">=20" },
+  "keywords": [
+    "claude",
+    "claude-code",
+    "mcp",
+    "ipc"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.mts"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,6 +1,6 @@
+import { readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { readFileSync } from 'node:fs'
 
 export const STATE_DIR = join(homedir(), '.claude', 'channels', 'channel-mux')
 export const ACCESS_FILE = join(STATE_DIR, 'access.json')

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,37 +1,36 @@
-export type {
-  Access,
-  GroupPolicy,
-  PendingEntry,
-  InboundMsg,
-  RegisterMsg,
-  ToolCallMsg,
-  UnregisterMsg,
-  PingMsg,
-  PluginMessage,
-  RegisterAckMsg,
-  ToolResultMsg,
-  PongMsg,
-  ShutdownMsg,
-  DaemonMessage,
-  Session,
-  GateResult,
-  RawPlatformMessage,
-  PlatformAdapter,
-  ToolCallHandler,
-} from './types.js'
-export { DEFAULT_ACCESS } from './types.js'
-
 export {
-  STATE_DIR,
   ACCESS_FILE,
+  APPROVED_DIR,
   ENV_FILE,
+  INBOX_DIR,
+  loadEnvFile,
   PID_FILE,
   SOCK_PATH,
-  INBOX_DIR,
-  APPROVED_DIR,
-  loadEnvFile,
+  STATE_DIR,
 } from './config.js'
+export { evaluateGate, type GateInput } from './gate.js'
+export { DEFAULT_REQUEST_TIMEOUT_MS, IpcClient } from './ipc-client.js'
 
 export { IpcServer } from './ipc-server.js'
-export { IpcClient, DEFAULT_REQUEST_TIMEOUT_MS } from './ipc-client.js'
-export { evaluateGate, type GateInput } from './gate.js'
+export type {
+  Access,
+  DaemonMessage,
+  GateResult,
+  GroupPolicy,
+  InboundMsg,
+  PendingEntry,
+  PingMsg,
+  PlatformAdapter,
+  PluginMessage,
+  PongMsg,
+  RawPlatformMessage,
+  RegisterAckMsg,
+  RegisterMsg,
+  Session,
+  ShutdownMsg,
+  ToolCallHandler,
+  ToolCallMsg,
+  ToolResultMsg,
+  UnregisterMsg,
+} from './types.js'
+export { DEFAULT_ACCESS } from './types.js'

--- a/packages/core/src/ipc-client.ts
+++ b/packages/core/src/ipc-client.ts
@@ -1,11 +1,6 @@
-import net from 'node:net'
 import { randomUUID } from 'node:crypto'
-import type {
-  DaemonMessage,
-  InboundMsg,
-  RegisterAckMsg,
-  ToolResultMsg,
-} from './types.js'
+import net from 'node:net'
+import type { DaemonMessage, InboundMsg, RegisterAckMsg, ToolResultMsg } from './types.js'
 
 export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
 
@@ -143,7 +138,7 @@ export class IpcClient {
 
   private send(msg: Record<string, unknown>): void {
     if (!this.socket) throw new Error('not connected')
-    this.socket.write(JSON.stringify(msg) + '\n')
+    this.socket.write(`${JSON.stringify(msg)}\n`)
   }
 
   private waitForResponse(id: string): Promise<DaemonMessage> {

--- a/packages/core/src/ipc-server.ts
+++ b/packages/core/src/ipc-server.ts
@@ -1,14 +1,14 @@
-import net from 'node:net'
 import { unlinkSync } from 'node:fs'
+import net from 'node:net'
 import type {
-  Session,
+  DaemonMessage,
   InboundMsg,
   PluginMessage,
   RegisterMsg,
+  Session,
+  ToolCallHandler,
   ToolCallMsg,
   UnregisterMsg,
-  ToolCallHandler,
-  DaemonMessage,
 } from './types.js'
 
 export class IpcServer {
@@ -249,6 +249,6 @@ export class IpcServer {
   }
 
   private send(socket: net.Socket, msg: DaemonMessage): void {
-    socket.write(JSON.stringify(msg) + '\n')
+    socket.write(`${JSON.stringify(msg)}\n`)
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -140,11 +140,7 @@ export interface PlatformAdapter {
     files?: string[]
   }): Promise<{ sentIds: string[] }>
 
-  react(args: {
-    chat_id: string
-    message_id: string
-    emoji: string
-  }): Promise<void>
+  react(args: { chat_id: string; message_id: string; emoji: string }): Promise<void>
 
   editMessage(args: {
     chat_id: string
@@ -152,10 +148,7 @@ export interface PlatformAdapter {
     text: string
   }): Promise<{ editedId: string }>
 
-  fetchMessages(args: {
-    channel: string
-    limit?: number
-  }): Promise<string>
+  fetchMessages(args: { channel: string; limit?: number }): Promise<string>
 
   downloadAttachment(args: {
     chat_id: string

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { writeFileSync, mkdirSync, rmSync } from 'node:fs'
-import { join } from 'node:path'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { loadEnvFile } from '../src/config.js'
 
 describe('loadEnvFile()', () => {

--- a/packages/core/tests/gate.test.ts
+++ b/packages/core/tests/gate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { evaluateGate, type GateInput } from '../src/gate.js'
 import type { Access } from '../src/types.js'
 
@@ -94,9 +94,27 @@ describe('evaluateGate() DM', () => {
   it('drops when 3 pending codes already exist', () => {
     const access = makeAccess({
       pending: {
-        aaa: { senderId: 'other-1', chatId: 'c', createdAt: 0, expiresAt: Date.now() + 3600000, replies: 1 },
-        bbb: { senderId: 'other-2', chatId: 'c', createdAt: 0, expiresAt: Date.now() + 3600000, replies: 1 },
-        ccc: { senderId: 'other-3', chatId: 'c', createdAt: 0, expiresAt: Date.now() + 3600000, replies: 1 },
+        aaa: {
+          senderId: 'other-1',
+          chatId: 'c',
+          createdAt: 0,
+          expiresAt: Date.now() + 3600000,
+          replies: 1,
+        },
+        bbb: {
+          senderId: 'other-2',
+          chatId: 'c',
+          createdAt: 0,
+          expiresAt: Date.now() + 3600000,
+          replies: 1,
+        },
+        ccc: {
+          senderId: 'other-3',
+          chatId: 'c',
+          createdAt: 0,
+          expiresAt: Date.now() + 3600000,
+          replies: 1,
+        },
       },
     })
     const result = evaluateGate(makeInput({ isDM: true }), access)
@@ -155,11 +173,14 @@ describe('evaluateGate() guild', () => {
     const access = makeAccess({
       groups: { 'parent-ch': { requireMention: false, allowFrom: [] } },
     })
-    const result = evaluateGate(makeInput({
-      channelId: 'thread-ch',
-      isThread: true,
-      parentChannelId: 'parent-ch',
-    }), access)
+    const result = evaluateGate(
+      makeInput({
+        channelId: 'thread-ch',
+        isThread: true,
+        parentChannelId: 'parent-ch',
+      }),
+      access,
+    )
     expect(result.action).toBe('deliver')
   })
 
@@ -167,11 +188,14 @@ describe('evaluateGate() guild', () => {
     const access = makeAccess({
       groups: { 'thread-ch': { requireMention: false, allowFrom: [] } },
     })
-    const result = evaluateGate(makeInput({
-      channelId: 'thread-ch',
-      isThread: true,
-      parentChannelId: undefined,
-    }), access)
+    const result = evaluateGate(
+      makeInput({
+        channelId: 'thread-ch',
+        isThread: true,
+        parentChannelId: undefined,
+      }),
+      access,
+    )
     expect(result.action).toBe('deliver')
   })
 })

--- a/packages/core/tests/ipc.test.ts
+++ b/packages/core/tests/ipc.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { mkdirSync, rmSync } from 'node:fs'
-import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { IpcServer } from '../src/ipc-server.js'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { IpcClient } from '../src/ipc-client.js'
+import { IpcServer } from '../src/ipc-server.js'
 import type { InboundMsg } from '../src/types.js'
 
 describe('IPC server/client', () => {
@@ -161,7 +161,7 @@ describe('IPC server/client', () => {
   })
 
   it('forwards tool calls and returns results', async () => {
-    server.onToolCall(async (tool, args) => {
+    server.onToolCall(async (tool, _args) => {
       if (tool === 'reply') {
         return { sentIds: ['sent-1'], result: 'ok' }
       }
@@ -215,9 +215,9 @@ describe('IPC server/client', () => {
     await client.register('session-1', [], false)
 
     const start = Date.now()
-    await expect(
-      client.toolCall('session-1', 'reply', { text: 'hello' }),
-    ).rejects.toThrow('timed out')
+    await expect(client.toolCall('session-1', 'reply', { text: 'hello' })).rejects.toThrow(
+      'timed out',
+    )
     const elapsed = Date.now() - start
 
     expect(elapsed).toBeGreaterThanOrEqual(150)
@@ -234,8 +234,12 @@ describe('IPC server/client', () => {
 
     let shutdown1 = false
     let shutdown2 = false
-    client1.onShutdown(() => { shutdown1 = true })
-    client2.onShutdown(() => { shutdown2 = true })
+    client1.onShutdown(() => {
+      shutdown1 = true
+    })
+    client2.onShutdown(() => {
+      shutdown2 = true
+    })
 
     server.broadcastShutdown()
     await new Promise((r) => setTimeout(r, 50))

--- a/packages/discord/package.json
+++ b/packages/discord/package.json
@@ -13,8 +13,16 @@
     "url": "https://github.com/HealGaren/claude-channel-mux.git",
     "directory": "packages/discord"
   },
-  "keywords": ["claude", "claude-code", "discord", "mcp", "channel"],
-  "engines": { "node": ">=20" },
+  "keywords": [
+    "claude",
+    "claude-code",
+    "discord",
+    "mcp",
+    "channel"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
   "bin": {
     "channel-mux-daemon": "./dist/daemon.mjs",
     "channel-mux-plugin": "./dist/plugin.mjs"
@@ -25,7 +33,11 @@
       "types": "./dist/index.d.mts"
     }
   },
-  "files": ["dist", "skills", ".claude-plugin"],
+  "files": [
+    "dist",
+    "skills",
+    ".claude-plugin"
+  ],
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",

--- a/packages/discord/src/access.ts
+++ b/packages/discord/src/access.ts
@@ -1,11 +1,11 @@
-import { readFileSync, writeFileSync, readdirSync, rmSync } from 'node:fs'
+import { readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import {
   ACCESS_FILE,
+  type Access,
   APPROVED_DIR,
   DEFAULT_ACCESS,
   evaluateGate,
-  type Access,
   type GateResult,
 } from '@claude-channel-mux/core'
 import type { Client, Message } from 'discord.js'
@@ -21,7 +21,7 @@ export function readAccessFile(): Access {
 }
 
 export function saveAccess(a: Access): void {
-  writeFileSync(ACCESS_FILE, JSON.stringify(a, null, 2) + '\n')
+  writeFileSync(ACCESS_FILE, `${JSON.stringify(a, null, 2)}\n`)
 }
 
 export function pruneExpired(a: Access): boolean {
@@ -48,16 +48,19 @@ export async function gate(
   const isThread = !isDM && msg.channel.isThread()
 
   // Resolve mention before calling pure gate logic (guild messages only)
-  const mentioned = !isDM && await isMentioned(msg, client, recentSentIds, access.mentionPatterns)
+  const mentioned = !isDM && (await isMentioned(msg, client, recentSentIds, access.mentionPatterns))
 
-  const result = evaluateGate({
-    senderId: msg.author.id,
-    channelId: msg.channelId,
-    isDM,
-    isThread,
-    parentChannelId: isThread ? (msg.channel.parentId ?? undefined) : undefined,
-    isMentioned: mentioned,
-  }, access)
+  const result = evaluateGate(
+    {
+      senderId: msg.author.id,
+      channelId: msg.channelId,
+      isDM,
+      isThread,
+      parentChannelId: isThread ? (msg.channel.parentId ?? undefined) : undefined,
+      isMentioned: mentioned,
+    },
+    access,
+  )
 
   // Persist access changes from pairing
   if (result.action === 'pair') {
@@ -93,9 +96,7 @@ export async function isMentioned(
   return false
 }
 
-export function checkApprovals(
-  fetchTextChannel: (id: string) => Promise<unknown>,
-): void {
+export function checkApprovals(fetchTextChannel: (id: string) => Promise<unknown>): void {
   let files: string[]
   try {
     files = readdirSync(APPROVED_DIR)

--- a/packages/discord/src/adapter.ts
+++ b/packages/discord/src/adapter.ts
@@ -1,27 +1,27 @@
-import {
-  Client,
-  GatewayIntentBits,
-  Partials,
-  ChannelType,
-  type Message,
-  type TextChannel,
-  type DMChannel,
-  type ThreadChannel,
-  AttachmentBuilder,
-} from 'discord.js'
-import { mkdirSync, writeFileSync, readFileSync, statSync } from 'node:fs'
+import { mkdirSync, statSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import type { PlatformAdapter, InboundMsg, GateResult } from '@claude-channel-mux/core'
+import type { GateResult, InboundMsg, PlatformAdapter } from '@claude-channel-mux/core'
 import { INBOX_DIR } from '@claude-channel-mux/core'
-import { gate as gateCheck, readAccessFile, checkApprovals } from './access.js'
 import {
-  chunk,
+  AttachmentBuilder,
+  ChannelType,
+  Client,
+  type DMChannel,
+  GatewayIntentBits,
+  type Message,
+  Partials,
+  type TextChannel,
+  type ThreadChannel,
+} from 'discord.js'
+import { checkApprovals, gate as gateCheck, readAccessFile } from './access.js'
+import {
   assertSendable,
-  safeAttName,
-  noteSent,
-  MAX_CHUNK_LIMIT,
+  chunk,
   MAX_ATTACHMENT_BYTES,
   MAX_ATTACHMENT_COUNT,
+  MAX_CHUNK_LIMIT,
+  noteSent,
+  safeAttName,
 } from './utils.js'
 
 type SendableChannel = TextChannel | DMChannel | ThreadChannel
@@ -63,9 +63,7 @@ export class DiscordAdapter implements PlatformAdapter {
       checkApprovals((id) => this.fetchTextChannel(id))
     }, 5000)
 
-    process.stderr.write(
-      `channel-mux discord: logged in as ${this.client.user?.tag}\n`,
-    )
+    process.stderr.write(`channel-mux discord: logged in as ${this.client.user?.tag}\n`)
   }
 
   async disconnect(): Promise<void> {
@@ -111,9 +109,7 @@ export class DiscordAdapter implements PlatformAdapter {
     const sentIds: string[] = []
     for (let i = 0; i < chunks.length; i++) {
       const shouldReplyTo =
-        args.reply_to != null &&
-        replyMode !== 'off' &&
-        (replyMode === 'all' || i === 0)
+        args.reply_to != null && replyMode !== 'off' && (replyMode === 'all' || i === 0)
 
       const sent = await ch.send({
         content: chunks[i],
@@ -129,11 +125,7 @@ export class DiscordAdapter implements PlatformAdapter {
     return { sentIds }
   }
 
-  async react(args: {
-    chat_id: string
-    message_id: string
-    emoji: string
-  }): Promise<void> {
+  async react(args: { chat_id: string; message_id: string; emoji: string }): Promise<void> {
     const ch = await this.fetchAllowedChannel(args.chat_id)
     const msg = await ch.messages.fetch(args.message_id)
     await msg.react(args.emoji)
@@ -153,10 +145,7 @@ export class DiscordAdapter implements PlatformAdapter {
     return { editedId: msg.id }
   }
 
-  async fetchMessages(args: {
-    channel: string
-    limit?: number
-  }): Promise<string> {
+  async fetchMessages(args: { channel: string; limit?: number }): Promise<string> {
     const ch = await this.fetchAllowedChannel(args.channel)
     const limit = Math.min(args.limit ?? 20, 100)
     const messages = await ch.messages.fetch({ limit })
@@ -166,9 +155,7 @@ export class DiscordAdapter implements PlatformAdapter {
       .map(
         (m) =>
           `[${m.createdAt.toISOString()}] ${m.author.username}: ${m.content}` +
-          (m.attachments.size > 0
-            ? ` [${m.attachments.size} attachment(s)]`
-            : ''),
+          (m.attachments.size > 0 ? ` [${m.attachments.size} attachment(s)]` : ''),
       )
 
     return lines.join('\n')
@@ -308,7 +295,7 @@ export class DiscordAdapter implements PlatformAdapter {
       const recipientId = ch.recipientId
       if (recipientId && access.allowFrom.includes(recipientId)) return ch
     } else {
-      const key = ch.isThread() ? (ch as ThreadChannel).parentId ?? ch.id : ch.id
+      const key = ch.isThread() ? ((ch as ThreadChannel).parentId ?? ch.id) : ch.id
       if (key in access.groups) return ch
     }
 

--- a/packages/discord/src/daemon.ts
+++ b/packages/discord/src/daemon.ts
@@ -1,6 +1,6 @@
-import { mkdirSync, writeFileSync, unlinkSync } from 'node:fs'
+import { mkdirSync, unlinkSync, writeFileSync } from 'node:fs'
+import { IpcServer, loadEnvFile, PID_FILE, SOCK_PATH, STATE_DIR } from '@claude-channel-mux/core'
 import { DiscordAdapter } from './adapter.js'
-import { IpcServer, loadEnvFile, SOCK_PATH, PID_FILE, STATE_DIR } from '@claude-channel-mux/core'
 
 async function main() {
   loadEnvFile()
@@ -37,7 +37,9 @@ async function main() {
       case 'edit_message':
         return adapter.editMessage(args as Parameters<typeof adapter.editMessage>[0])
       case 'fetch_messages': {
-        const result = await adapter.fetchMessages(args as Parameters<typeof adapter.fetchMessages>[0])
+        const result = await adapter.fetchMessages(
+          args as Parameters<typeof adapter.fetchMessages>[0],
+        )
         return { result }
       }
       case 'download_attachment':
@@ -55,8 +57,12 @@ async function main() {
     ipc.broadcastShutdown()
     ipc.stop()
     adapter.disconnect()
-    try { unlinkSync(PID_FILE) } catch {}
-    try { unlinkSync(SOCK_PATH) } catch {}
+    try {
+      unlinkSync(PID_FILE)
+    } catch {}
+    try {
+      unlinkSync(SOCK_PATH)
+    } catch {}
     process.exit(0)
   }
   process.on('SIGTERM', shutdown)

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -1,3 +1,3 @@
+export { pruneExpired, readAccessFile, saveAccess } from './access.js'
 export { DiscordAdapter } from './adapter.js'
-export { readAccessFile, saveAccess, pruneExpired } from './access.js'
-export { chunk, assertSendable, safeAttName, noteSent } from './utils.js'
+export { assertSendable, chunk, noteSent, safeAttName } from './utils.js'

--- a/packages/discord/src/plugin.ts
+++ b/packages/discord/src/plugin.ts
@@ -1,11 +1,8 @@
 import { randomUUID } from 'node:crypto'
+import { IpcClient, SOCK_PATH } from '@claude-channel-mux/core'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
-import {
-  ListToolsRequestSchema,
-  CallToolRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js'
-import { IpcClient, SOCK_PATH } from '@claude-channel-mux/core'
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 
 const sessionId = randomUUID()
 
@@ -30,7 +27,7 @@ if (!ack.ok) {
   process.exit(1)
 }
 
-const botUsername = ack.botUsername ?? 'channel-mux-bot'
+const _botUsername = ack.botUsername ?? 'channel-mux-bot'
 
 const mcp = new Server(
   { name: 'channel-mux', version: '0.1.0' },

--- a/packages/discord/src/utils.ts
+++ b/packages/discord/src/utils.ts
@@ -1,6 +1,6 @@
 import { realpathSync } from 'node:fs'
 import { join, sep } from 'node:path'
-import { STATE_DIR, INBOX_DIR } from '@claude-channel-mux/core'
+import { STATE_DIR } from '@claude-channel-mux/core'
 import type { Attachment } from 'discord.js'
 
 export const MAX_CHUNK_LIMIT = 2000
@@ -42,7 +42,7 @@ export function assertSendable(f: string): void {
 }
 
 export function safeAttName(att: Attachment): string {
-  return (att.name ?? att.id).replace(/[\[\]\r\n;]/g, '_')
+  return (att.name ?? att.id).replace(/[[\]\r\n;]/g, '_')
 }
 
 export function noteSent(recentSentIds: Set<string>, id: string): void {

--- a/packages/discord/tests/access.test.ts
+++ b/packages/discord/tests/access.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { writeFileSync, mkdirSync, rmSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import type { Access } from '@claude-channel-mux/core'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Mock config paths before importing access module
 const testDir = join(tmpdir(), `channel-mux-access-test-${process.pid}`)
@@ -20,9 +20,7 @@ vi.mock('@claude-channel-mux/core', () => ({
 }))
 
 // Import after mock
-const { readAccessFile, saveAccess, pruneExpired } = await import(
-  '../src/access.js'
-)
+const { readAccessFile, saveAccess, pruneExpired } = await import('../src/access.js')
 
 describe('access file operations', () => {
   beforeEach(() => {
@@ -63,7 +61,7 @@ describe('access file operations', () => {
     }
     saveAccess(data)
     const raw = readFileSync(accessFile, 'utf8')
-    expect(raw).toContain('  ')  // indented
+    expect(raw).toContain('  ') // indented
     const parsed = JSON.parse(raw)
     expect(parsed.allowFrom).toEqual(['user-1'])
   })
@@ -80,14 +78,14 @@ describe('pruneExpired()', () => {
           senderId: 'u1',
           chatId: 'ch1',
           createdAt: Date.now() - 7200000,
-          expiresAt: Date.now() - 3600000,  // expired 1h ago
+          expiresAt: Date.now() - 3600000, // expired 1h ago
           replies: 1,
         },
         def456: {
           senderId: 'u2',
           chatId: 'ch2',
           createdAt: Date.now(),
-          expiresAt: Date.now() + 3600000,  // expires in 1h
+          expiresAt: Date.now() + 3600000, // expires in 1h
           replies: 1,
         },
       },

--- a/packages/discord/tests/assert-sendable.test.ts
+++ b/packages/discord/tests/assert-sendable.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const testDir = join(tmpdir(), `channel-mux-sendable-test-${process.pid}`)
 

--- a/packages/discord/tests/utils.test.ts
+++ b/packages/discord/tests/utils.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest'
 import type { Attachment } from 'discord.js'
-import { chunk, safeAttName, noteSent, RECENT_SENT_CAP } from '../src/utils.js'
+import { describe, expect, it } from 'vitest'
+import { chunk, noteSent, RECENT_SENT_CAP, safeAttName } from '../src/utils.js'
 
 describe('chunk()', () => {
   it('returns single-element array when text fits within limit', () => {
@@ -24,7 +24,7 @@ describe('chunk()', () => {
 
   describe('newline mode', () => {
     it('prefers paragraph breaks', () => {
-      const long = 'a'.repeat(6) + '\n\n' + 'b'.repeat(6) + '\n\n' + 'c'.repeat(6)
+      const long = `${'a'.repeat(6)}\n\n${'b'.repeat(6)}\n\n${'c'.repeat(6)}`
       const result = chunk(long, 15, 'newline')
       expect(result[0]).toBe('aaaaaa\n\nbbbbbb')
       expect(result[1]).toBe('cccccc')


### PR DESCRIPTION
## Summary
- Apply Biome auto-fixes across the codebase (21 files)
- Add `pnpm run lint` step to CI pipeline

## Changes
Mostly auto-fixed by `biome check --write --unsafe`:
- String concatenation to template literals
- Import ordering
- Trailing commas
- Minor style corrections

No logic changes.

## Test plan
- [x] `pnpm run lint` passes (0 issues)
- [x] `pnpm run build` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (59/59)

🤖 Generated with [Claude Code](https://claude.com/claude-code)