### PR TITLE
Fix release script: sync workspace package versions

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -12,7 +12,8 @@
     "releaseName": "v${version}"
   },
   "hooks": {
-    "before:init": ["pnpm run build", "pnpm run typecheck", "pnpm test"]
+    "before:init": ["pnpm run build", "pnpm run typecheck", "pnpm test"],
+    "after:bump": "npx tsx scripts/sync-versions.ts"
   },
   "plugins": {
     "@release-it/conventional-changelog": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "claude-channel-mux-root",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "description": "Multiplex Claude Code channel sessions through a single Discord bot",
@@ -26,8 +27,8 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
-    "release": "pnpm -r exec release-it --no-git --no-github --no-npm && release-it",
-    "release:alpha": "pnpm -r exec release-it --no-git --no-github --no-npm --preRelease=alpha && release-it --preRelease=alpha"
+    "release": "release-it",
+    "release:alpha": "release-it --preRelease=alpha"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",

--- a/scripts/sync-versions.ts
+++ b/scripts/sync-versions.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env tsx
+/**
+ * Sync the root package.json version to all workspace packages.
+ * Called by release-it after:bump hook.
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ROOT = join(import.meta.dirname, '..')
+const rootPkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'))
+const version = rootPkg.version
+
+if (!version) {
+  process.stderr.write('sync-versions: no version found in root package.json\n')
+  process.exit(1)
+}
+
+const packages = ['core', 'discord', 'cli']
+
+for (const pkg of packages) {
+  const pkgPath = join(ROOT, 'packages', pkg, 'package.json')
+  const pkgJson = JSON.parse(readFileSync(pkgPath, 'utf8'))
+  pkgJson.version = version
+  writeFileSync(pkgPath, `${JSON.stringify(pkgJson, null, 2)}\n`)
+  process.stderr.write(`sync-versions: ${pkgJson.name} -> ${version}\n`)
+}


### PR DESCRIPTION
Closes #39

## Problem
`pnpm release:alpha` only bumped root package.json version. Individual packages stayed at 0.1.0 and got published with that version.

## Fix
- `scripts/sync-versions.ts`: copies root version to all workspace package.json files
- release-it `after:bump` hook runs the sync script
- Simplified release scripts (removed broken `pnpm -r exec release-it` approach)
- Added `version` field to root package.json for release-it to bump

## Flow
1. release-it bumps root `package.json` version
2. `after:bump` hook runs `sync-versions.ts`
3. All packages now have the same version
4. release-it commits, tags, pushes
5. CI publishes all packages with the correct version

## Test plan
- [x] `npx tsx scripts/sync-versions.ts` syncs all package versions
- [x] `pnpm run build` passes
- [x] `pnpm run test` passes (59/59)
- [x] `pnpm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)