### PR TITLE
Use npm Trusted Publishers for CI publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,4 @@ jobs:
             echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
           fi
       - name: Publish all packages
-        run: pnpm -r publish --tag ${{ steps.tag.outputs.npm_tag }} --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm -r publish --tag ${{ steps.tag.outputs.npm_tag }} --access public --no-git-checks --provenance


### PR DESCRIPTION
## Summary
Switch from NPM_TOKEN secret to OIDC Trusted Publishers for npm publish.

## Changes
- Remove `NODE_AUTH_TOKEN` env var from publish workflow
- Add `--provenance` flag to `pnpm -r publish`
- npm verifies identity via GitHub Actions OIDC, no secret needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)