### PR TITLE
Fix OIDC trusted publishing (clear NODE_AUTH_TOKEN)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org
+          node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
@@ -40,5 +39,5 @@ jobs:
           for pkg in packages/core packages/discord packages/cli; do
             echo "Publishing $pkg..."
             cd "$GITHUB_WORKSPACE/$pkg"
-            npm publish --tag "$TAG" --access public --provenance
+            NODE_AUTH_TOKEN="" npm publish --tag "$TAG" --access public --provenance
           done


### PR DESCRIPTION
## Problem
`npm publish --provenance` fails with 404 because `setup-node` sets a default `NODE_AUTH_TOKEN` that conflicts with OIDC authentication.

Ref:
- https://github.com/orgs/community/discussions/176761
- https://github.com/actions/setup-node/issues/1440

## Fix
- `NODE_AUTH_TOKEN=""` before `npm publish` to let OIDC work
- Node 22 for reliable OIDC support (npm >= 11.5)
- Remove `registry-url` from setup-node (not needed with trusted publishers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)