### PR TITLE
Fix: use pnpm publish to resolve workspace:* protocol

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,5 +43,5 @@ jobs:
           for pkg in packages/core packages/discord packages/cli; do
             echo "Publishing $pkg..."
             cd "$GITHUB_WORKSPACE/$pkg"
-            npm publish --tag "$TAG" --access public
+            pnpm publish --tag "$TAG" --access public --no-git-checks
           done


### PR DESCRIPTION
## Problem
`npm publish` leaves `workspace:*` as-is in published package.json, making the package uninstallable.

## Fix
Switch to `pnpm publish` which automatically replaces `workspace:*` with the actual version.

## Verified locally
- `pnpm pack` produces tarballs with resolved versions (e.g. `"@claude-channel-mux/core": "0.1.0-alpha.2"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)