### PR TITLE
Move GitHub Release creation to CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 permissions:
-  contents: read
+  contents: write
   # OIDC trusted publishing planned, keeping id-token for future use
   id-token: write
 
@@ -30,10 +30,13 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           if echo "$VERSION" | grep -q "alpha"; then
             echo "npm_tag=alpha" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
           elif echo "$VERSION" | grep -q "beta"; then
             echo "npm_tag=beta" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Publish packages
         env:
@@ -45,3 +48,20 @@ jobs:
             cd "$GITHUB_WORKSPACE/$pkg"
             pnpm publish --tag "$TAG" --access public --no-git-checks
           done
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          PRERELEASE="${{ steps.tag.outputs.prerelease }}"
+          FLAGS=""
+          if [ "$PRERELEASE" = "true" ]; then
+            FLAGS="--prerelease"
+          fi
+          # Extract current version section from CHANGELOG.md
+          VERSION="${TAG#v}"
+          NOTES=$(sed -n "/^# ${VERSION}/,/^# [0-9]/p" CHANGELOG.md | sed '1d;$d')
+          if [ -z "$NOTES" ]; then
+            NOTES="Release ${TAG}"
+          fi
+          gh release create "$TAG" --title "$TAG" --notes "$NOTES" $FLAGS

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,9 +59,10 @@ jobs:
             FLAGS="--prerelease"
           fi
           # Extract current version section from CHANGELOG.md
+          # Header format: "# 0.1.0-alpha.2 (2026-03-21)"
           VERSION="${TAG#v}"
-          NOTES=$(sed -n "/^# ${VERSION}/,/^# [0-9]/p" CHANGELOG.md | sed '1d;$d')
+          NOTES=$(awk "/^#+ .*${VERSION}/{found=1; next} /^#+ [0-9]/{if(found) exit} found" CHANGELOG.md)
           if [ -z "$NOTES" ]; then
             NOTES="Release ${TAG}"
           fi
-          gh release create "$TAG" --title "$TAG" --notes "$NOTES" $FLAGS
+          gh release create "$TAG" --title "$TAG" --notes "$NOTES" ${FLAGS:+$FLAGS}

--- a/.release-it.json
+++ b/.release-it.json
@@ -8,8 +8,7 @@
     "publish": false
   },
   "github": {
-    "release": true,
-    "releaseName": "v${version}"
+    "release": false
   },
   "hooks": {
     "before:init": ["pnpm run build", "pnpm run typecheck", "pnpm test"],


### PR DESCRIPTION
Closes #51

## Summary
GitHub Release is now created by CI after npm publish, instead of locally by release-it.

## Changes
- publish.yml: add `gh release create` step with CHANGELOG.md notes extraction
- publish.yml: `contents: write` permission for release creation
- publish.yml: prerelease flag for alpha/beta tags
- .release-it.json: `github.release: false`
- No GITHUB_TOKEN needed for local release

## Flow
1. Local: `pnpm release:alpha` -> bump, changelog, commit, tag, push
2. CI: build, test, npm publish, then create GitHub Release with notes from CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)