### PR TITLE
Fix: add shebang to bin entrypoints

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { execSync, spawn } from 'node:child_process'
 import { closeSync, existsSync, mkdirSync, openSync, readFileSync, unlinkSync } from 'node:fs'
 import { join } from 'node:path'

--- a/packages/discord/src/daemon.ts
+++ b/packages/discord/src/daemon.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { mkdirSync, unlinkSync, writeFileSync } from 'node:fs'
 import { IpcServer, loadEnvFile, PID_FILE, SOCK_PATH, STATE_DIR } from '@claude-channel-mux/core'
 import { DiscordAdapter } from './adapter.js'

--- a/packages/discord/src/plugin.ts
+++ b/packages/discord/src/plugin.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { randomUUID } from 'node:crypto'
 import { IpcClient, SOCK_PATH } from '@claude-channel-mux/core'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'


### PR DESCRIPTION
## Problem
npm bin symlinks (channel-mux, channel-mux-daemon, channel-mux-plugin) fail with "import: not found" because the .mjs files lack `#!/usr/bin/env node`. Shell tries to execute JS directly instead of via Node.

## Fix
Add `#!/usr/bin/env node` to source files:
- `packages/cli/src/cli.ts`
- `packages/discord/src/daemon.ts`
- `packages/discord/src/plugin.ts`

tsdown preserves the shebang in built output. npm auto-generates OS-appropriate wrappers (.cmd/.ps1 on Windows) for files in the `bin` field.

## Verified
- [x] Built output has shebang on first line
- [x] `node packages/cli/dist/cli.mjs status` works
- [x] `pnpm run test` passes (59/59)
- [x] `pnpm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)