### PR TITLE
Expand Discord bot permissions documentation

### DIFF
--- a/docs/guides/discord-setup.md
+++ b/docs/guides/discord-setup.md
@@ -20,26 +20,56 @@ In the **Bot** tab, under **Privileged Gateway Intents**, enable:
 
 - **Message Content Intent** (required to read message text)
 
-The other intents (Presence, Server Members) are not needed.
+The other intents (Presence, Server Members) are not needed currently.
 
 ## 4. Set Bot Permissions
 
-The bot needs these permissions:
+Select all permissions you want from the table below. We recommend enabling recommended permissions upfront so you don't need to re-invite later.
 
-| Permission | Why |
+### Required
+
+These are needed for core functionality:
+
+| Permission | What it enables |
 |---|---|
+| View Channels | See channel list and read messages |
 | Send Messages | Reply to users |
 | Read Message History | Fetch channel history |
 | Add Reactions | Ack reactions, emoji reactions |
 | Attach Files | Send file attachments |
 
+### Recommended
+
+These enable useful features that are available or planned:
+
+| Permission | What it enables |
+|---|---|
+| Embed Links | Rich message formatting (links, previews) |
+| Create Public Threads | Thread-based conversations |
+| Send Messages in Threads | Reply within threads |
+| Manage Messages | Pin messages, clean up conversations |
+| Change Nickname | Show bot status in server nickname |
+
+### Future (voice channel presence)
+
+These are for a planned feature that uses voice channel presence to indicate daemon/session status (e.g. connected = running, muted = idle). Not required now, but saves a re-invite later.
+
+| Permission | What it enables |
+|---|---|
+| Connect | Join voice channels |
+| Speak | Voice presence indication |
+| Video | Visual status indicator |
+| Use Voice Activity Detection | Activity-based status |
+
 ## 5. Generate Invite URL
 
 1. Go to **OAuth2 > URL Generator**
 2. Under **Scopes**, select `bot`
-3. Under **Bot Permissions**, select the permissions above
+3. Under **Bot Permissions**, select the permissions from the tables above
 4. Copy the generated URL
 5. Open it in your browser to invite the bot to your server
+
+> **Tip**: If you add permissions later, you'll need to re-invite the bot using a new URL with the updated permissions. Users won't lose any data.
 
 ## 6. Configure claude-channel-mux
 
@@ -71,5 +101,5 @@ You'll use these IDs in your `.mcp.json` configuration. See [MCP Configuration G
 - Make sure there are no extra spaces or quotes around the token
 
 ### Bot can't see a channel
-- Check the bot has permission to view that channel
+- Check the bot has **View Channels** permission
 - Some channels may have permission overrides that exclude the bot role


### PR DESCRIPTION
Closes #62

## Summary
Three-tier permission table in discord-setup.md:
- **Required**: core functionality (view, send, history, reactions, files)
- **Recommended**: useful features (embeds, threads, pin, nickname)
- **Future**: voice channel presence (connect, speak, video)

Users can grant all upfront to avoid re-inviting the bot later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)