### PR TITLE
feat: add plugin marketplace and fix channel capability

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "claude-channel-mux",
+  "owner": {
+    "name": "HealGaren"
+  },
+  "metadata": {
+    "description": "Multiplex Claude Code channel sessions through a single Discord bot"
+  },
+  "plugins": [
+    {
+      "name": "channel-mux",
+      "source": {
+        "source": "npm",
+        "package": "@claude-channel-mux/discord"
+      },
+      "description": "Discord channel multiplexer for Claude Code -- routes messages from a shared bot to multiple sessions"
+    }
+  ]
+}

--- a/packages/discord/.claude-plugin/plugin.json
+++ b/packages/discord/.claude-plugin/plugin.json
@@ -1,7 +1,13 @@
 {
   "name": "channel-mux",
   "version": "0.1.0",
-  "description": "Multiplexed Discord channel for Claude Code — routes messages from a shared bot to multiple sessions.",
-  "entrypoint": "../src/plugin.ts",
-  "runtime": "tsx"
+  "description": "Multiplexed Discord channel for Claude Code -- routes messages from a shared bot to multiple sessions.",
+  "mcpServers": {
+    "channel-mux": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/dist/plugin.mjs",
+      "env": {
+        "CHANNEL_MUX_HANDLE_DMS": "true"
+      }
+    }
+  }
 }

--- a/packages/discord/.claude-plugin/plugin.json
+++ b/packages/discord/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "channel-mux",
+  "version": "0.1.0-alpha.3",
   "description": "Multiplexed Discord channel for Claude Code -- routes messages from a shared bot to multiple sessions.",
   "mcpServers": {
     "channel-mux": {

--- a/packages/discord/.claude-plugin/plugin.json
+++ b/packages/discord/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "channel-mux",
-  "version": "0.1.0",
   "description": "Multiplexed Discord channel for Claude Code -- routes messages from a shared bot to multiple sessions.",
   "mcpServers": {
     "channel-mux": {

--- a/packages/discord/.claude-plugin/plugin.json
+++ b/packages/discord/.claude-plugin/plugin.json
@@ -4,7 +4,8 @@
   "description": "Multiplexed Discord channel for Claude Code -- routes messages from a shared bot to multiple sessions.",
   "mcpServers": {
     "channel-mux": {
-      "command": "${CLAUDE_PLUGIN_ROOT}/dist/plugin.mjs",
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/plugin.mjs"],
       "env": {
         "CHANNEL_MUX_HANDLE_DMS": "true"
       }

--- a/packages/discord/src/plugin.ts
+++ b/packages/discord/src/plugin.ts
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
+import { createRequire } from 'node:module'
 import { randomUUID } from 'node:crypto'
 import { IpcClient, SOCK_PATH } from '@claude-channel-mux/core'
+
+const require = createRequire(import.meta.url)
+const { version } = require('../package.json') as { version: string }
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
@@ -31,7 +35,7 @@ if (!ack.ok) {
 const _botUsername = ack.botUsername ?? 'channel-mux-bot'
 
 const mcp = new Server(
-  { name: 'channel-mux', version: '0.1.0' },
+  { name: 'channel-mux', version },
   {
     capabilities: { experimental: { 'claude/channel': {} }, tools: {} },
     instructions: [

--- a/packages/discord/src/plugin.ts
+++ b/packages/discord/src/plugin.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
-import { createRequire } from 'node:module'
 import { randomUUID } from 'node:crypto'
+import { createRequire } from 'node:module'
 import { IpcClient, SOCK_PATH } from '@claude-channel-mux/core'
 
 const require = createRequire(import.meta.url)
 const { version } = require('../package.json') as { version: string }
+
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'

--- a/packages/discord/src/plugin.ts
+++ b/packages/discord/src/plugin.ts
@@ -33,7 +33,7 @@ const _botUsername = ack.botUsername ?? 'channel-mux-bot'
 const mcp = new Server(
   { name: 'channel-mux', version: '0.1.0' },
   {
-    capabilities: { tools: {} },
+    capabilities: { experimental: { 'claude/channel': {} }, tools: {} },
     instructions: [
       'The sender reads Discord, not this session. Anything you want them to see must go through the reply tool — your transcript output never reaches their chat.',
       '',

--- a/scripts/sync-versions.ts
+++ b/scripts/sync-versions.ts
@@ -24,3 +24,10 @@ for (const pkg of packages) {
   writeFileSync(pkgPath, `${JSON.stringify(pkgJson, null, 2)}\n`)
   process.stderr.write(`sync-versions: ${pkgJson.name} -> ${version}\n`)
 }
+
+// Sync plugin.json version (used by Claude Code for update detection)
+const pluginJsonPath = join(ROOT, 'packages', 'discord', '.claude-plugin', 'plugin.json')
+const pluginJson = JSON.parse(readFileSync(pluginJsonPath, 'utf8'))
+pluginJson.version = version
+writeFileSync(pluginJsonPath, `${JSON.stringify(pluginJson, null, 2)}\n`)
+process.stderr.write(`sync-versions: plugin.json -> ${version}\n`)


### PR DESCRIPTION
Closes #70

## Summary
- Add `.claude-plugin/marketplace.json` at repo root so this repo serves as a Claude Code plugin marketplace (npm source: `@claude-channel-mux/discord`)
- Update `packages/discord/.claude-plugin/plugin.json` to use `mcpServers` with built output for npm-based installation
- Declare `claude/channel` capability in MCP server so Claude Code recognizes it as a channel
- Read version from `package.json` at runtime instead of hardcoding; sync `plugin.json` version via `sync-versions.ts` during release

## User-facing change

Users can install via the plugin marketplace:
```
/plugin marketplace add HealGaren/claude-channel-mux
/plugin install channel-mux@claude-channel-mux
```

And use the `--dangerously-load-development-channels` flag to test as a channel:
```
claude --dangerously-load-development-channels plugin:channel-mux@claude-channel-mux
```

## Test results
- [x] Marketplace add (local path)
- [x] Plugin install from marketplace
- [x] MCP server connects to daemon
- [x] DM pairing and messaging
- [x] Guild channel messaging (after group add)
- [x] Multi-session channel multiplexing

🤖 Generated with [Claude Code](https://claude.com/claude-code)