### PR TITLE
feat: add verbose debug logging

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -178,6 +178,11 @@ switch (command) {
   }
 
   default:
-    console.log('Usage: channel-mux <start [--verbose|-v]|stop|status>')
+    console.log('Usage: channel-mux <start|stop|status>')
+    console.log('')
+    console.log('Commands:')
+    console.log('  start [--verbose]   Start the daemon (--verbose enables debug logs)')
+    console.log('  stop                Stop the daemon')
+    console.log('  status              Show daemon status')
     process.exit(1)
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -77,7 +77,7 @@ const command = process.argv[2]
 
 switch (command) {
   case 'start': {
-    const verbose = process.argv.includes('--verbose') || process.argv.includes('-v')
+    const verbose = process.argv.includes('--verbose')
 
     const pid = readPid()
     if (pid && isProcessAlive(pid)) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -77,6 +77,8 @@ const command = process.argv[2]
 
 switch (command) {
   case 'start': {
+    const verbose = process.argv.includes('--verbose') || process.argv.includes('-v')
+
     const pid = readPid()
     if (pid && isProcessAlive(pid)) {
       console.log(`channel-mux daemon already running (pid ${pid})`)
@@ -102,7 +104,10 @@ switch (command) {
     const child = spawn(runner, runnerArgs, {
       stdio: ['ignore', 'ignore', logFd],
       detached: true,
-      env: { ...process.env },
+      env: {
+        ...process.env,
+        ...(verbose ? { CHANNEL_MUX_DEBUG: '1' } : {}),
+      },
     })
     child.unref()
     closeSync(logFd)
@@ -114,6 +119,7 @@ switch (command) {
     if (newPid && isProcessAlive(newPid)) {
       console.log(`channel-mux daemon started (pid ${newPid})`)
       console.log(`  log: ${logPath}`)
+      if (verbose) console.log('  verbose logging enabled')
     } else {
       console.error('channel-mux: daemon failed to start. Check daemon.log')
       process.exit(1)
@@ -172,6 +178,6 @@ switch (command) {
   }
 
   default:
-    console.log('Usage: channel-mux <start|stop|status>')
+    console.log('Usage: channel-mux <start|stop|status> [--verbose|-v]')
     process.exit(1)
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -178,6 +178,6 @@ switch (command) {
   }
 
   default:
-    console.log('Usage: channel-mux <start|stop|status> [--verbose|-v]')
+    console.log('Usage: channel-mux <start [--verbose|-v]|stop|status>')
     process.exit(1)
 }

--- a/packages/core/src/debug.ts
+++ b/packages/core/src/debug.ts
@@ -1,0 +1,19 @@
+function isEnabled(): boolean {
+  return process.env.CHANNEL_MUX_DEBUG === '1' || process.env.CHANNEL_MUX_DEBUG === 'true'
+}
+
+type DebugFn = {
+  (...args: unknown[]): void
+  readonly enabled: boolean
+}
+
+export function createDebug(prefix: string): DebugFn {
+  const fn = (...args: unknown[]) => {
+    if (!isEnabled()) return
+    const ts = new Date().toISOString()
+    const msg = args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')
+    process.stderr.write(`[${ts}] ${prefix}: ${msg}\n`)
+  }
+  Object.defineProperty(fn, 'enabled', { get: isEnabled })
+  return fn as DebugFn
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export {
   SOCK_PATH,
   STATE_DIR,
 } from './config.js'
+export { createDebug } from './debug.js'
 export { evaluateGate, type GateInput } from './gate.js'
 export { DEFAULT_REQUEST_TIMEOUT_MS, IpcClient } from './ipc-client.js'
 

--- a/packages/core/src/ipc-client.ts
+++ b/packages/core/src/ipc-client.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from 'node:crypto'
 import net from 'node:net'
+import { createDebug } from './debug.js'
 import type { DaemonMessage, InboundMsg, RegisterAckMsg, ToolResultMsg } from './types.js'
+
+const dbg = createDebug('mux:ipc-client')
 
 export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
 
@@ -28,6 +31,7 @@ export class IpcClient {
     return new Promise((resolve, reject) => {
       const socket = net.createConnection(this.sockPath, () => {
         this.socket = socket
+        dbg('connected', this.sockPath)
         resolve()
       })
 
@@ -125,12 +129,15 @@ export class IpcClient {
 
     // Inbound message from Discord
     if (msg.type === 'inbound' && this.messageHandler) {
-      this.messageHandler(msg)
+      const inbound = msg as InboundMsg
+      dbg('inbound', `channel=${inbound.channelId}`, `message=${inbound.messageId}`)
+      this.messageHandler(msg as InboundMsg)
       return
     }
 
     // Daemon shutdown
     if (msg.type === 'shutdown' && this.shutdownHandler) {
+      dbg('shutdown received')
       this.shutdownHandler()
       return
     }

--- a/packages/core/src/ipc-client.ts
+++ b/packages/core/src/ipc-client.ts
@@ -131,7 +131,7 @@ export class IpcClient {
     if (msg.type === 'inbound' && this.messageHandler) {
       const inbound = msg as InboundMsg
       dbg('inbound', `channel=${inbound.channelId}`, `message=${inbound.messageId}`)
-      this.messageHandler(msg as InboundMsg)
+      this.messageHandler(inbound)
       return
     }
 

--- a/packages/core/src/ipc-server.ts
+++ b/packages/core/src/ipc-server.ts
@@ -65,19 +65,20 @@ export class IpcServer {
       sessionId = this.channelToSession.get(msg.channelId)
     }
 
-    dbg(
-      'routeInbound',
-      `channel=${msg.channelId}`,
-      `isDM=${msg.isDM}`,
-      `session=${sessionId ?? 'none'}`,
-      `registered=[${[...this.channelToSession.keys()].join(',')}]`,
-    )
-
-    if (!sessionId) return false
+    if (!sessionId) {
+      dbg(
+        'routeInbound miss',
+        `channel=${msg.channelId}`,
+        `isDM=${msg.isDM}`,
+        `registered=[${[...this.channelToSession.keys()].join(', ')}]`,
+      )
+      return false
+    }
 
     const session = this.sessions.get(sessionId)
     if (!session) return false
 
+    dbg('routeInbound hit', `channel=${msg.channelId}`, `-> session ${sessionId}`)
     this.send(session.socket, msg)
     return true
   }

--- a/packages/core/src/ipc-server.ts
+++ b/packages/core/src/ipc-server.ts
@@ -1,5 +1,6 @@
 import { unlinkSync } from 'node:fs'
 import net from 'node:net'
+import { createDebug } from './debug.js'
 import type {
   DaemonMessage,
   InboundMsg,
@@ -10,6 +11,8 @@ import type {
   ToolCallMsg,
   UnregisterMsg,
 } from './types.js'
+
+const dbg = createDebug('mux:ipc-server')
 
 export class IpcServer {
   private server: net.Server | null = null
@@ -61,6 +64,14 @@ export class IpcServer {
     } else {
       sessionId = this.channelToSession.get(msg.channelId)
     }
+
+    dbg(
+      'routeInbound',
+      `channel=${msg.channelId}`,
+      `isDM=${msg.isDM}`,
+      `session=${sessionId ?? 'none'}`,
+      `registered=[${[...this.channelToSession.keys()].join(',')}]`,
+    )
 
     if (!sessionId) return false
 

--- a/packages/core/tests/debug.test.ts
+++ b/packages/core/tests/debug.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createDebug } from '../src/debug.js'
+
+describe('createDebug', () => {
+  const originalEnv = process.env.CHANNEL_MUX_DEBUG
+
+  beforeEach(() => {
+    delete process.env.CHANNEL_MUX_DEBUG
+  })
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.CHANNEL_MUX_DEBUG = originalEnv
+    } else {
+      delete process.env.CHANNEL_MUX_DEBUG
+    }
+  })
+
+  it('does not write when disabled', () => {
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const dbg = createDebug('test')
+    dbg('hello')
+    expect(spy).not.toHaveBeenCalled()
+    spy.mockRestore()
+  })
+
+  it('reports enabled=false when env var is not set', () => {
+    const dbg = createDebug('test')
+    expect(dbg.enabled).toBe(false)
+  })
+
+  it('writes to stderr when CHANNEL_MUX_DEBUG=1', () => {
+    process.env.CHANNEL_MUX_DEBUG = '1'
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const dbg = createDebug('mux:test')
+    dbg('hello', 'world')
+    expect(spy).toHaveBeenCalledOnce()
+    const output = spy.mock.calls[0][0] as string
+    expect(output).toContain('mux:test:')
+    expect(output).toContain('hello world')
+    expect(output).toMatch(/^\[.*T.*Z\]/) // ISO timestamp
+    spy.mockRestore()
+  })
+
+  it('reports enabled=true when CHANNEL_MUX_DEBUG=true', () => {
+    process.env.CHANNEL_MUX_DEBUG = 'true'
+    const dbg = createDebug('test')
+    expect(dbg.enabled).toBe(true)
+  })
+
+  it('JSON-stringifies non-string arguments', () => {
+    process.env.CHANNEL_MUX_DEBUG = '1'
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const dbg = createDebug('test')
+    dbg('data', { key: 'value' })
+    const output = spy.mock.calls[0][0] as string
+    expect(output).toContain('{"key":"value"}')
+    spy.mockRestore()
+  })
+
+  it('reflects env changes dynamically', () => {
+    const dbg = createDebug('test')
+    expect(dbg.enabled).toBe(false)
+    process.env.CHANNEL_MUX_DEBUG = '1'
+    expect(dbg.enabled).toBe(true)
+    delete process.env.CHANNEL_MUX_DEBUG
+    expect(dbg.enabled).toBe(false)
+  })
+})

--- a/packages/discord/src/adapter.ts
+++ b/packages/discord/src/adapter.ts
@@ -229,7 +229,14 @@ export class DiscordAdapter implements PlatformAdapter {
     if (msg.author.bot) return
 
     const gateResult = await this.gate({ platform: 'discord', raw: msg })
-    dbg('gate', `channel=${msg.channelId}`, `user=${msg.author.id}`, `action=${gateResult.action}`)
+    if (dbg.enabled) {
+      dbg(
+        'gate',
+        `channel=${msg.channelId}`,
+        `user=${msg.author.id}`,
+        `action=${gateResult.action}`,
+      )
+    }
 
     if (gateResult.action === 'pair') {
       await this.sendPairingCode(msg.channelId, gateResult.code, gateResult.isResend)

--- a/packages/discord/src/adapter.ts
+++ b/packages/discord/src/adapter.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, statSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import type { GateResult, InboundMsg, PlatformAdapter } from '@claude-channel-mux/core'
-import { INBOX_DIR } from '@claude-channel-mux/core'
+import { createDebug, INBOX_DIR } from '@claude-channel-mux/core'
 import {
   AttachmentBuilder,
   ChannelType,
@@ -25,6 +25,8 @@ import {
 } from './utils.js'
 
 type SendableChannel = TextChannel | DMChannel | ThreadChannel
+
+const dbg = createDebug('mux:discord')
 
 export class DiscordAdapter implements PlatformAdapter {
   name = 'discord'
@@ -227,6 +229,7 @@ export class DiscordAdapter implements PlatformAdapter {
     if (msg.author.bot) return
 
     const gateResult = await this.gate({ platform: 'discord', raw: msg })
+    dbg('gate', `channel=${msg.channelId}`, `user=${msg.author.id}`, `action=${gateResult.action}`)
 
     if (gateResult.action === 'pair') {
       await this.sendPairingCode(msg.channelId, gateResult.code, gateResult.isResend)

--- a/packages/discord/src/daemon.ts
+++ b/packages/discord/src/daemon.ts
@@ -34,12 +34,14 @@ async function main() {
 
   adapter.onMessage((msg) => {
     const routed = ipc.routeInbound(msg)
-    dbg(
-      routed ? 'routed' : 'dropped (no matching session)',
-      `channel=${msg.channelId}`,
-      `user=${msg.username}`,
-      `isDM=${msg.isDM}`,
-    )
+    if (dbg.enabled) {
+      dbg(
+        routed ? 'routed' : 'dropped (no matching session)',
+        `channel=${msg.channelId}`,
+        `user=${msg.username}`,
+        `isDM=${msg.isDM}`,
+      )
+    }
   })
 
   ipc.onToolCall(async (tool, args) => {

--- a/packages/discord/src/daemon.ts
+++ b/packages/discord/src/daemon.ts
@@ -1,7 +1,16 @@
 #!/usr/bin/env node
 import { mkdirSync, unlinkSync, writeFileSync } from 'node:fs'
-import { IpcServer, loadEnvFile, PID_FILE, SOCK_PATH, STATE_DIR } from '@claude-channel-mux/core'
+import {
+  createDebug,
+  IpcServer,
+  loadEnvFile,
+  PID_FILE,
+  SOCK_PATH,
+  STATE_DIR,
+} from '@claude-channel-mux/core'
 import { DiscordAdapter } from './adapter.js'
+
+const dbg = createDebug('mux:daemon')
 
 async function main() {
   loadEnvFile()
@@ -24,10 +33,13 @@ async function main() {
   const adapter = new DiscordAdapter()
 
   adapter.onMessage((msg) => {
-    ipc.routeInbound(msg)
+    dbg('inbound', `channel=${msg.channelId}`, `user=${msg.username}`, `isDM=${msg.isDM}`)
+    const routed = ipc.routeInbound(msg)
+    dbg(routed ? 'routed' : 'no matching session')
   })
 
   ipc.onToolCall(async (tool, args) => {
+    dbg('tool_call', tool, Object.keys(args as Record<string, unknown>))
     switch (tool) {
       case 'reply':
         return adapter.reply(args as Parameters<typeof adapter.reply>[0])

--- a/packages/discord/src/daemon.ts
+++ b/packages/discord/src/daemon.ts
@@ -33,9 +33,13 @@ async function main() {
   const adapter = new DiscordAdapter()
 
   adapter.onMessage((msg) => {
-    dbg('inbound', `channel=${msg.channelId}`, `user=${msg.username}`, `isDM=${msg.isDM}`)
     const routed = ipc.routeInbound(msg)
-    dbg(routed ? 'routed' : 'no matching session')
+    dbg(
+      routed ? 'routed' : 'dropped (no matching session)',
+      `channel=${msg.channelId}`,
+      `user=${msg.username}`,
+      `isDM=${msg.isDM}`,
+    )
   })
 
   ipc.onToolCall(async (tool, args) => {

--- a/packages/discord/src/plugin.ts
+++ b/packages/discord/src/plugin.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { randomUUID } from 'node:crypto'
 import { createRequire } from 'node:module'
-import { IpcClient, SOCK_PATH } from '@claude-channel-mux/core'
+import { createDebug, IpcClient, SOCK_PATH } from '@claude-channel-mux/core'
 
 const require = createRequire(import.meta.url)
 const { version } = require('../package.json') as { version: string }
@@ -9,6 +9,8 @@ const { version } = require('../package.json') as { version: string }
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+
+const dbg = createDebug('mux:plugin')
 
 const sessionId = randomUUID()
 
@@ -129,6 +131,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
 }))
 
 mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
+  dbg('tool_call', req.params.name)
   const args = (req.params.arguments ?? {}) as Record<string, unknown>
   try {
     const result = await ipc.toolCall(sessionId, req.params.name, args)
@@ -149,6 +152,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
 })
 
 ipc.onInbound((msg) => {
+  dbg('inbound', `channel=${msg.channelId}`, `message=${msg.messageId}`, `user=${msg.username}`)
   const atts = msg.attachments
   const meta: Record<string, string> = {
     chat_id: msg.channelId,
@@ -163,6 +167,7 @@ ipc.onInbound((msg) => {
       .map((a) => `${a.name} (${a.contentType}, ${Math.round(a.size / 1024)}KB)`)
       .join('; ')
   }
+  dbg('sending mcp notification', msg.messageId)
   void mcp.notification({
     method: 'notifications/claude/channel',
     params: {

--- a/packages/discord/src/plugin.ts
+++ b/packages/discord/src/plugin.ts
@@ -152,7 +152,6 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
 })
 
 ipc.onInbound((msg) => {
-  dbg('inbound', `channel=${msg.channelId}`, `message=${msg.messageId}`, `user=${msg.username}`)
   const atts = msg.attachments
   const meta: Record<string, string> = {
     chat_id: msg.channelId,
@@ -167,7 +166,7 @@ ipc.onInbound((msg) => {
       .map((a) => `${a.name} (${a.contentType}, ${Math.round(a.size / 1024)}KB)`)
       .join('; ')
   }
-  dbg('sending mcp notification', msg.messageId)
+  dbg('notify', `channel=${msg.channelId}`, `message=${msg.messageId}`, `user=${msg.username}`)
   void mcp.notification({
     method: 'notifications/claude/channel',
     params: {

--- a/packages/discord/src/plugin.ts
+++ b/packages/discord/src/plugin.ts
@@ -166,7 +166,9 @@ ipc.onInbound((msg) => {
       .map((a) => `${a.name} (${a.contentType}, ${Math.round(a.size / 1024)}KB)`)
       .join('; ')
   }
-  dbg('notify', `channel=${msg.channelId}`, `message=${msg.messageId}`, `user=${msg.username}`)
+  if (dbg.enabled) {
+    dbg('notify', `channel=${msg.channelId}`, `message=${msg.messageId}`, `user=${msg.username}`)
+  }
   void mcp.notification({
     method: 'notifications/claude/channel',
     params: {


### PR DESCRIPTION
## Summary
- Add `createDebug()` utility in `@claude-channel-mux/core` that outputs timestamped logs to stderr when `CHANNEL_MUX_DEBUG=1` (or `true`)
- Add debug logs across the full message path: Discord adapter gate result, daemon inbound routing, IPC server/client message passing, and plugin MCP notification
- CLI `channel-mux start --verbose` flag to start the daemon with debug logging enabled
- Users can also set `CHANNEL_MUX_DEBUG=1` in `~/.claude/channels/channel-mux/.env` for persistent debug mode
- Hot-path debug calls guarded with `dbg.enabled` to avoid template literal evaluation when disabled

## Usage
```bash
# Start daemon with verbose logging
channel-mux start --verbose

# Or set env var
CHANNEL_MUX_DEBUG=1 channel-mux start

# Or add to .env for persistent debug
echo 'CHANNEL_MUX_DEBUG=1' >> ~/.claude/channels/channel-mux/.env
```

Debug output in `daemon.log`:
```
[2026-03-21T02:58:15.123Z] mux:discord: gate channel=123 user=456 action=deliver
[2026-03-21T02:58:15.124Z] mux:ipc-server: routeInbound hit channel=123 -> session abc
[2026-03-21T02:58:15.124Z] mux:daemon: routed channel=123 user=alice isDM=false
[2026-03-21T02:58:15.125Z] mux:plugin: notify channel=123 message=789 user=alice
```

When routing fails:
```
[2026-03-21T02:58:15.123Z] mux:discord: gate channel=999 user=456 action=deliver
[2026-03-21T02:58:15.124Z] mux:ipc-server: routeInbound miss channel=999 isDM=false registered=[123, 456]
[2026-03-21T02:58:15.124Z] mux:daemon: dropped (no matching session) channel=999 user=bob isDM=false
```

CLI help:
```
Usage: channel-mux <start|stop|status>

Commands:
  start [--verbose]   Start the daemon (--verbose enables debug logs)
  stop                Stop the daemon
  status              Show daemon status
```

## Test plan
- [x] Unit tests for `createDebug()` (6 tests covering enabled/disabled, dynamic env, JSON serialization)
- [x] All existing tests pass (`pnpm run test`)
- [x] Lint, build, typecheck pass
- [ ] Manual: start daemon with `--verbose`, send Discord message, verify debug logs in `daemon.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)