### PR TITLE
feat: add daemon monitoring HTTP server

### DIFF
--- a/docs/guides/monitor-api.md
+++ b/docs/guides/monitor-api.md
@@ -1,0 +1,82 @@
+# Monitor API (Experimental)
+
+> **Status**: Experimental. API spec is subject to change.
+
+Optional HTTP server for observing daemon state. Disabled by default.
+
+## Enable
+
+Set `MONITOR_PORT` in `~/.claude/channels/channel-mux/.env`:
+
+```
+MONITOR_PORT=9100
+```
+
+Then restart the daemon. The server binds to `127.0.0.1` only.
+
+## Endpoints
+
+### `GET /status`
+
+Daemon summary.
+
+```json
+{
+  "uptime": 123,
+  "sessionCount": 2,
+  "botUsername": "my-bot",
+  "requestBufferSize": 15
+}
+```
+
+### `GET /sessions`
+
+Connected Claude Code sessions.
+
+```json
+[
+  {
+    "sessionId": "abc-123",
+    "channels": ["1234567890"],
+    "handleDMs": false,
+    "connectedAt": 1711000000000
+  }
+]
+```
+
+### `GET /requests`
+
+Recent request log (last 200 entries, ring buffer).
+
+```json
+[
+  {
+    "timestamp": "2026-03-21T12:00:00.000Z",
+    "direction": "inbound",
+    "type": "message",
+    "channelId": "1234567890",
+    "summary": "alice: hello"
+  },
+  {
+    "timestamp": "2026-03-21T12:00:01.000Z",
+    "direction": "outbound",
+    "type": "reply",
+    "channelId": "1234567890",
+    "summary": "reply({...}) -> ok"
+  }
+]
+```
+
+### `GET /events`
+
+SSE (Server-Sent Events) stream. Events: `inbound`, `tool_call`, `session_connect`, `session_disconnect`.
+
+```
+curl -N http://127.0.0.1:9100/events
+```
+
+```
+data: {"event":"inbound","data":{...},"timestamp":"2026-03-21T12:00:00.000Z"}
+
+data: {"event":"tool_call","data":{...},"timestamp":"2026-03-21T12:00:01.000Z"}
+```

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,7 +2,7 @@
 import { execSync, spawn } from 'node:child_process'
 import { closeSync, existsSync, mkdirSync, openSync, readFileSync, unlinkSync } from 'node:fs'
 import { join } from 'node:path'
-import { PID_FILE, SOCK_PATH, STATE_DIR } from '@claude-channel-mux/core'
+import { MONITOR_PORT_FILE, PID_FILE, SOCK_PATH, STATE_DIR } from '@claude-channel-mux/core'
 
 function isProcessAlive(pid: number): boolean {
   try {
@@ -169,6 +169,12 @@ switch (command) {
       console.log(`channel-mux daemon: running (pid ${pid})`)
       console.log(`  socket: ${SOCK_PATH} (${sockExists ? 'exists' : 'missing'})`)
       console.log(`  state: ${STATE_DIR}`)
+      try {
+        const port = readFileSync(MONITOR_PORT_FILE, 'utf8').trim()
+        console.log(`  monitor: http://127.0.0.1:${port}`)
+      } catch {
+        // monitor not enabled
+      }
     } else {
       console.log('channel-mux daemon: stopped')
       if (pid) console.log(`  stale pid file: ${PID_FILE}`)

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -29,6 +29,9 @@ function cleanupStateFiles(): void {
   try {
     unlinkSync(SOCK_PATH)
   } catch {}
+  try {
+    unlinkSync(MONITOR_PORT_FILE)
+  } catch {}
 }
 
 /**

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -9,6 +9,7 @@ export const PID_FILE = join(STATE_DIR, 'daemon.pid')
 export const SOCK_PATH = join(STATE_DIR, 'daemon.sock')
 export const INBOX_DIR = join(STATE_DIR, 'inbox')
 export const APPROVED_DIR = join(STATE_DIR, 'approved')
+export const MONITOR_PORT_FILE = join(STATE_DIR, 'monitor.port')
 
 const ENV_LINE = /^(\w+)=(.*)$/
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,7 +18,6 @@ export {
   type MonitorEvent,
   MonitorServer,
   type RequestLogEntry,
-  type SessionSnapshot,
   type StatusProvider,
 } from './monitor.js'
 export { RingBuffer } from './ring-buffer.js'
@@ -37,6 +36,7 @@ export type {
   RegisterAckMsg,
   RegisterMsg,
   Session,
+  SessionSnapshot,
   ShutdownMsg,
   ToolCallHandler,
   ToolCallMsg,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ export {
   ENV_FILE,
   INBOX_DIR,
   loadEnvFile,
+  MONITOR_PORT_FILE,
   PID_FILE,
   SOCK_PATH,
   STATE_DIR,
@@ -13,6 +14,14 @@ export { evaluateGate, type GateInput } from './gate.js'
 export { DEFAULT_REQUEST_TIMEOUT_MS, IpcClient } from './ipc-client.js'
 
 export { IpcServer } from './ipc-server.js'
+export {
+  type MonitorEvent,
+  MonitorServer,
+  type RequestLogEntry,
+  type SessionSnapshot,
+  type StatusProvider,
+} from './monitor.js'
+export { RingBuffer } from './ring-buffer.js'
 export type {
   Access,
   DaemonMessage,

--- a/packages/core/src/ipc-server.ts
+++ b/packages/core/src/ipc-server.ts
@@ -48,6 +48,20 @@ export class IpcServer {
     this.server = null
   }
 
+  getSessionSnapshots(): Array<{
+    sessionId: string
+    channels: string[]
+    handleDMs: boolean
+    connectedAt: number
+  }> {
+    return [...this.sessions.values()].map((s) => ({
+      sessionId: s.sessionId,
+      channels: [...s.channels],
+      handleDMs: s.handleDMs,
+      connectedAt: s.connectedAt,
+    }))
+  }
+
   setBotUsername(name: string): void {
     this.botUsername = name
   }
@@ -170,6 +184,7 @@ export class IpcServer {
       socket,
       channels: new Set(msg.channels),
       handleDMs: msg.handleDMs,
+      connectedAt: existing?.connectedAt ?? Date.now(),
     }
 
     this.sessions.set(msg.sessionId, session)

--- a/packages/core/src/ipc-server.ts
+++ b/packages/core/src/ipc-server.ts
@@ -66,7 +66,7 @@ export class IpcServer {
     this.toolCallHandler = handler
   }
 
-  routeInbound(msg: InboundMsg): boolean {
+  routeInbound(msg: InboundMsg): string | null {
     let sessionId: string | undefined
 
     if (msg.isDM) {
@@ -82,15 +82,15 @@ export class IpcServer {
         `isDM=${msg.isDM}`,
         `registered=[${[...this.channelToSession.keys()].join(', ')}]`,
       )
-      return false
+      return null
     }
 
     const session = this.sessions.get(sessionId)
-    if (!session) return false
+    if (!session) return null
 
     dbg('routeInbound hit', `channel=${msg.channelId}`, `-> session ${sessionId}`)
     this.send(session.socket, msg)
-    return true
+    return sessionId
   }
 
   broadcastShutdown(): void {

--- a/packages/core/src/ipc-server.ts
+++ b/packages/core/src/ipc-server.ts
@@ -7,6 +7,7 @@ import type {
   PluginMessage,
   RegisterMsg,
   Session,
+  SessionSnapshot,
   ToolCallHandler,
   ToolCallMsg,
   UnregisterMsg,
@@ -48,12 +49,7 @@ export class IpcServer {
     this.server = null
   }
 
-  getSessionSnapshots(): Array<{
-    sessionId: string
-    channels: string[]
-    handleDMs: boolean
-    connectedAt: number
-  }> {
+  getSessionSnapshots(): SessionSnapshot[] {
     return [...this.sessions.values()].map((s) => ({
       sessionId: s.sessionId,
       channels: [...s.channels],

--- a/packages/core/src/monitor.ts
+++ b/packages/core/src/monitor.ts
@@ -1,15 +1,9 @@
 import http from 'node:http'
 import { createDebug } from './debug.js'
 import { RingBuffer } from './ring-buffer.js'
+import type { SessionSnapshot } from './types.js'
 
 const dbg = createDebug('mux:monitor')
-
-export type SessionSnapshot = {
-  sessionId: string
-  channels: string[]
-  handleDMs: boolean
-  connectedAt: number
-}
 
 export type RequestLogEntry = {
   timestamp: string
@@ -21,8 +15,8 @@ export type RequestLogEntry = {
 }
 
 export type MonitorEvent = {
-  event: string
-  data: Record<string, unknown>
+  event: 'inbound' | 'tool_call' | 'session_connect' | 'session_disconnect'
+  data: RequestLogEntry | { sessionId: string }
   timestamp: string
 }
 
@@ -95,11 +89,7 @@ export class MonitorServer {
       summary: truncate(`${msg.username}: ${msg.content}`),
     }
     this.requests.push(entry)
-    this.emit({
-      event: 'inbound',
-      data: entry as unknown as Record<string, unknown>,
-      timestamp: entry.timestamp,
-    })
+    this.emit({ event: 'inbound', data: entry, timestamp: entry.timestamp })
   }
 
   recordToolCall(
@@ -108,29 +98,25 @@ export class MonitorServer {
     ok: boolean,
     sessionId?: string,
   ): void {
+    const argsPreview = truncate(JSON.stringify(args), 150)
     const entry: RequestLogEntry = {
       timestamp: new Date().toISOString(),
       direction: 'outbound',
       type: tool,
       channelId: args.chat_id as string | undefined,
       sessionId,
-      summary: truncate(`${tool}(${JSON.stringify(args)}) -> ${ok ? 'ok' : 'error'}`),
+      summary: `${tool}(${argsPreview}) -> ${ok ? 'ok' : 'error'}`,
     }
     this.requests.push(entry)
-    this.emit({
-      event: 'tool_call',
-      data: entry as unknown as Record<string, unknown>,
-      timestamp: entry.timestamp,
-    })
+    this.emit({ event: 'tool_call', data: entry, timestamp: entry.timestamp })
   }
 
   recordSessionEvent(type: 'connect' | 'disconnect', sessionId: string): void {
-    const event: MonitorEvent = {
+    this.emit({
       event: `session_${type}`,
       data: { sessionId },
       timestamp: new Date().toISOString(),
-    }
-    this.emit(event)
+    })
   }
 
   private handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
@@ -182,14 +168,20 @@ export class MonitorServer {
     res.write(':ok\n\n')
 
     this.sseClients.add(res)
-    res.on('close', () => this.sseClients.delete(res))
-    res.on('error', () => this.sseClients.delete(res))
+    const cleanup = () => this.sseClients.delete(res)
+    res.on('close', cleanup)
+    res.on('error', cleanup)
   }
 
   private emit(event: MonitorEvent): void {
+    if (this.sseClients.size === 0) return
     const line = `data: ${JSON.stringify(event)}\n\n`
     for (const res of this.sseClients) {
-      res.write(line)
+      try {
+        res.write(line)
+      } catch {
+        this.sseClients.delete(res)
+      }
     }
   }
 

--- a/packages/core/src/monitor.ts
+++ b/packages/core/src/monitor.ts
@@ -1,0 +1,204 @@
+import http from 'node:http'
+import { createDebug } from './debug.js'
+import { RingBuffer } from './ring-buffer.js'
+
+const dbg = createDebug('mux:monitor')
+
+export type SessionSnapshot = {
+  sessionId: string
+  channels: string[]
+  handleDMs: boolean
+  connectedAt: number
+}
+
+export type RequestLogEntry = {
+  timestamp: string
+  direction: 'inbound' | 'outbound'
+  type: string
+  channelId?: string
+  sessionId?: string
+  summary: string
+}
+
+export type MonitorEvent = {
+  event: string
+  data: Record<string, unknown>
+  timestamp: string
+}
+
+export type StatusProvider = () => {
+  uptime: number
+  sessions: SessionSnapshot[]
+  botUsername: string | null
+}
+
+const MAX_SUMMARY = 200
+
+function truncate(s: string, max = MAX_SUMMARY): string {
+  return s.length > max ? `${s.slice(0, max)}...` : s
+}
+
+export class MonitorServer {
+  private server: http.Server | null = null
+  private requests: RingBuffer<RequestLogEntry>
+  private sseClients = new Set<http.ServerResponse>()
+
+  constructor(
+    private statusProvider: StatusProvider,
+    options?: { bufferSize?: number },
+  ) {
+    this.requests = new RingBuffer(options?.bufferSize ?? 200)
+  }
+
+  start(port: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const server = http.createServer((req, res) => this.handleRequest(req, res))
+
+      server.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EADDRINUSE') {
+          process.stderr.write(`channel-mux monitor: port ${port} in use, monitor disabled\n`)
+          reject(err)
+          return
+        }
+        process.stderr.write(`channel-mux monitor: error: ${err.message}\n`)
+      })
+
+      server.listen(port, '127.0.0.1', () => {
+        this.server = server
+        dbg(`listening on http://127.0.0.1:${port}`)
+        resolve()
+      })
+    })
+  }
+
+  stop(): void {
+    for (const res of this.sseClients) {
+      res.end()
+    }
+    this.sseClients.clear()
+    this.server?.close()
+    this.server = null
+  }
+
+  recordInbound(msg: {
+    channelId: string
+    username: string
+    content: string
+    sessionId?: string
+  }): void {
+    const entry: RequestLogEntry = {
+      timestamp: new Date().toISOString(),
+      direction: 'inbound',
+      type: 'message',
+      channelId: msg.channelId,
+      sessionId: msg.sessionId,
+      summary: truncate(`${msg.username}: ${msg.content}`),
+    }
+    this.requests.push(entry)
+    this.emit({
+      event: 'inbound',
+      data: entry as unknown as Record<string, unknown>,
+      timestamp: entry.timestamp,
+    })
+  }
+
+  recordToolCall(
+    tool: string,
+    args: Record<string, unknown>,
+    ok: boolean,
+    sessionId?: string,
+  ): void {
+    const entry: RequestLogEntry = {
+      timestamp: new Date().toISOString(),
+      direction: 'outbound',
+      type: tool,
+      channelId: args.chat_id as string | undefined,
+      sessionId,
+      summary: truncate(`${tool}(${JSON.stringify(args)}) -> ${ok ? 'ok' : 'error'}`),
+    }
+    this.requests.push(entry)
+    this.emit({
+      event: 'tool_call',
+      data: entry as unknown as Record<string, unknown>,
+      timestamp: entry.timestamp,
+    })
+  }
+
+  recordSessionEvent(type: 'connect' | 'disconnect', sessionId: string): void {
+    const event: MonitorEvent = {
+      event: `session_${type}`,
+      data: { sessionId },
+      timestamp: new Date().toISOString(),
+    }
+    this.emit(event)
+  }
+
+  private handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
+    const url = new URL(req.url ?? '/', `http://${req.headers.host}`)
+
+    switch (url.pathname) {
+      case '/status':
+        this.handleStatus(res)
+        break
+      case '/sessions':
+        this.handleSessions(res)
+        break
+      case '/requests':
+        this.handleRequests(res)
+        break
+      case '/events':
+        this.handleEvents(req, res)
+        break
+      default:
+        this.json(res, 404, { error: 'not found' })
+    }
+  }
+
+  private handleStatus(res: http.ServerResponse): void {
+    const status = this.statusProvider()
+    this.json(res, 200, {
+      uptime: status.uptime,
+      sessionCount: status.sessions.length,
+      botUsername: status.botUsername,
+      requestBufferSize: this.requests.size,
+    })
+  }
+
+  private handleSessions(res: http.ServerResponse): void {
+    const status = this.statusProvider()
+    this.json(res, 200, status.sessions)
+  }
+
+  private handleRequests(res: http.ServerResponse): void {
+    this.json(res, 200, this.requests.toArray())
+  }
+
+  private handleEvents(_req: http.IncomingMessage, res: http.ServerResponse): void {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    })
+    res.write(':ok\n\n')
+
+    this.sseClients.add(res)
+    res.on('close', () => this.sseClients.delete(res))
+    res.on('error', () => this.sseClients.delete(res))
+  }
+
+  private emit(event: MonitorEvent): void {
+    const line = `data: ${JSON.stringify(event)}\n\n`
+    for (const res of this.sseClients) {
+      res.write(line)
+    }
+  }
+
+  private json(res: http.ServerResponse, status: number, data: unknown): void {
+    const body = JSON.stringify(data)
+    res.writeHead(status, {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(body),
+    })
+    res.end(body)
+  }
+}

--- a/packages/core/src/monitor.ts
+++ b/packages/core/src/monitor.ts
@@ -65,6 +65,11 @@ export class MonitorServer {
     })
   }
 
+  get port(): number | null {
+    const addr = this.server?.address()
+    return addr && typeof addr === 'object' ? addr.port : null
+  }
+
   stop(): void {
     for (const res of this.sseClients) {
       res.end()

--- a/packages/core/src/ring-buffer.ts
+++ b/packages/core/src/ring-buffer.ts
@@ -1,0 +1,26 @@
+export class RingBuffer<T> {
+  private buf: T[]
+  private head = 0
+  private count = 0
+
+  constructor(private capacity: number) {
+    this.buf = new Array(capacity)
+  }
+
+  push(item: T): void {
+    this.buf[this.head] = item
+    this.head = (this.head + 1) % this.capacity
+    if (this.count < this.capacity) this.count++
+  }
+
+  toArray(): T[] {
+    if (this.count < this.capacity) {
+      return this.buf.slice(0, this.count)
+    }
+    return [...this.buf.slice(this.head), ...this.buf.slice(0, this.head)]
+  }
+
+  get size(): number {
+    return this.count
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -115,6 +115,13 @@ export type Session = {
   connectedAt: number
 }
 
+export type SessionSnapshot = {
+  sessionId: string
+  channels: string[]
+  handleDMs: boolean
+  connectedAt: number
+}
+
 // ─── Platform Adapter ───
 
 export type GateResult =

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -112,6 +112,7 @@ export type Session = {
   socket: Socket
   channels: Set<string>
   handleDMs: boolean
+  connectedAt: number
 }
 
 // ─── Platform Adapter ───

--- a/packages/core/tests/ipc.test.ts
+++ b/packages/core/tests/ipc.test.ts
@@ -226,6 +226,28 @@ describe('IPC server/client', () => {
     client.disconnect('session-1')
   })
 
+  it('returns session snapshots', async () => {
+    const client1 = await createClient()
+    const client2 = await createClient()
+    await client1.register('session-1', ['ch-700'], false)
+    await client2.register('session-2', ['ch-701', 'ch-702'], true)
+
+    const snapshots = server.getSessionSnapshots()
+    expect(snapshots).toHaveLength(2)
+
+    const s1 = snapshots.find((s) => s.sessionId === 'session-1')!
+    expect(s1.channels).toEqual(['ch-700'])
+    expect(s1.handleDMs).toBe(false)
+    expect(s1.connectedAt).toBeGreaterThan(0)
+
+    const s2 = snapshots.find((s) => s.sessionId === 'session-2')!
+    expect(s2.channels).toEqual(expect.arrayContaining(['ch-701', 'ch-702']))
+    expect(s2.handleDMs).toBe(true)
+
+    client1.disconnect('session-1')
+    client2.disconnect('session-2')
+  })
+
   it('broadcasts shutdown to all connected clients', async () => {
     const client1 = await createClient()
     const client2 = await createClient()

--- a/packages/core/tests/ipc.test.ts
+++ b/packages/core/tests/ipc.test.ts
@@ -93,7 +93,7 @@ describe('IPC server/client', () => {
     }
 
     const routed = server.routeInbound(msg)
-    expect(routed).toBe(true)
+    expect(routed).toBe('session-1')
 
     // Wait for message to arrive
     await new Promise((r) => setTimeout(r, 50))
@@ -122,7 +122,7 @@ describe('IPC server/client', () => {
       isDM: true,
     }
 
-    expect(server.routeInbound(msg)).toBe(true)
+    expect(server.routeInbound(msg)).toBe('session-dm')
     await new Promise((r) => setTimeout(r, 50))
     expect(received).toHaveLength(1)
     expect(received[0].content).toBe('dm hello')
@@ -142,7 +142,7 @@ describe('IPC server/client', () => {
       attachments: [],
       isDM: false,
     }
-    expect(server.routeInbound(msg)).toBe(false)
+    expect(server.routeInbound(msg)).toBeNull()
   })
 
   it('releases claims on disconnect', async () => {

--- a/packages/core/tests/monitor.test.ts
+++ b/packages/core/tests/monitor.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { MonitorServer, type StatusProvider } from '../src/monitor.js'
+
+describe('MonitorServer', () => {
+  let monitor: MonitorServer
+  let port: number
+  const baseUrl = () => `http://127.0.0.1:${port}`
+
+  const statusProvider: StatusProvider = () => ({
+    uptime: 42,
+    sessions: [
+      { sessionId: 's1', channels: ['ch-1', 'ch-2'], handleDMs: false, connectedAt: 1000 },
+    ],
+    botUsername: 'test-bot',
+  })
+
+  beforeEach(async () => {
+    // Use random port to avoid conflicts
+    port = 10000 + Math.floor(Math.random() * 50000)
+    monitor = new MonitorServer(statusProvider, { bufferSize: 5 })
+    await monitor.start(port)
+  })
+
+  afterEach(() => {
+    monitor.stop()
+  })
+
+  it('GET /status returns daemon status', async () => {
+    const res = await fetch(`${baseUrl()}/status`)
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.uptime).toBe(42)
+    expect(data.sessionCount).toBe(1)
+    expect(data.botUsername).toBe('test-bot')
+  })
+
+  it('GET /sessions returns session list', async () => {
+    const res = await fetch(`${baseUrl()}/sessions`)
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data).toHaveLength(1)
+    expect(data[0].sessionId).toBe('s1')
+    expect(data[0].channels).toEqual(['ch-1', 'ch-2'])
+  })
+
+  it('GET /requests returns recorded events', async () => {
+    monitor.recordInbound({ channelId: 'ch-1', username: 'alice', content: 'hello' })
+    monitor.recordToolCall('reply', { chat_id: 'ch-1', text: 'hi' }, true)
+
+    const res = await fetch(`${baseUrl()}/requests`)
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data).toHaveLength(2)
+    expect(data[0].direction).toBe('inbound')
+    expect(data[0].type).toBe('message')
+    expect(data[1].direction).toBe('outbound')
+    expect(data[1].type).toBe('reply')
+  })
+
+  it('respects buffer size limit', async () => {
+    for (let i = 0; i < 10; i++) {
+      monitor.recordInbound({ channelId: 'ch-1', username: 'user', content: `msg-${i}` })
+    }
+
+    const res = await fetch(`${baseUrl()}/requests`)
+    const data = await res.json()
+    expect(data).toHaveLength(5)
+    expect(data[0].summary).toContain('msg-5')
+    expect(data[4].summary).toContain('msg-9')
+  })
+
+  it('returns 404 for unknown paths', async () => {
+    const res = await fetch(`${baseUrl()}/unknown`)
+    expect(res.status).toBe(404)
+    const data = await res.json()
+    expect(data.error).toBe('not found')
+  })
+
+  it('GET /events returns SSE stream', async () => {
+    const controller = new AbortController()
+    const res = await fetch(`${baseUrl()}/events`, { signal: controller.signal })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('text/event-stream')
+
+    const reader = res.body!.getReader()
+    const decoder = new TextDecoder()
+
+    // Read initial :ok comment
+    const { value: initial } = await reader.read()
+    expect(decoder.decode(initial)).toContain(':ok')
+
+    // Record an event
+    monitor.recordInbound({ channelId: 'ch-1', username: 'bob', content: 'test' })
+
+    // Read the SSE event
+    const { value: eventData } = await reader.read()
+    const text = decoder.decode(eventData)
+    expect(text).toContain('data:')
+    expect(text).toContain('"event":"inbound"')
+
+    controller.abort()
+  })
+
+  it('truncates long content in summaries', async () => {
+    const longContent = 'x'.repeat(500)
+    monitor.recordInbound({ channelId: 'ch-1', username: 'user', content: longContent })
+
+    const res = await fetch(`${baseUrl()}/requests`)
+    const data = await res.json()
+    expect(data[0].summary.length).toBeLessThan(250)
+    expect(data[0].summary).toContain('...')
+  })
+})

--- a/packages/core/tests/monitor.test.ts
+++ b/packages/core/tests/monitor.test.ts
@@ -15,10 +15,9 @@ describe('MonitorServer', () => {
   })
 
   beforeEach(async () => {
-    // Use random port to avoid conflicts
-    port = 10000 + Math.floor(Math.random() * 50000)
     monitor = new MonitorServer(statusProvider, { bufferSize: 5 })
-    await monitor.start(port)
+    await monitor.start(0)
+    port = monitor.port!
   })
 
   afterEach(() => {

--- a/packages/core/tests/ring-buffer.test.ts
+++ b/packages/core/tests/ring-buffer.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { RingBuffer } from '../src/ring-buffer.js'
+
+describe('RingBuffer', () => {
+  it('returns items in order within capacity', () => {
+    const buf = new RingBuffer<number>(5)
+    buf.push(1)
+    buf.push(2)
+    buf.push(3)
+    expect(buf.toArray()).toEqual([1, 2, 3])
+    expect(buf.size).toBe(3)
+  })
+
+  it('drops oldest items when over capacity', () => {
+    const buf = new RingBuffer<number>(3)
+    buf.push(1)
+    buf.push(2)
+    buf.push(3)
+    buf.push(4)
+    buf.push(5)
+    expect(buf.toArray()).toEqual([3, 4, 5])
+    expect(buf.size).toBe(3)
+  })
+
+  it('returns empty array when empty', () => {
+    const buf = new RingBuffer<string>(5)
+    expect(buf.toArray()).toEqual([])
+    expect(buf.size).toBe(0)
+  })
+
+  it('handles exactly capacity items', () => {
+    const buf = new RingBuffer<number>(3)
+    buf.push(1)
+    buf.push(2)
+    buf.push(3)
+    expect(buf.toArray()).toEqual([1, 2, 3])
+    expect(buf.size).toBe(3)
+  })
+
+  it('wraps around multiple times', () => {
+    const buf = new RingBuffer<number>(2)
+    for (let i = 1; i <= 10; i++) {
+      buf.push(i)
+    }
+    expect(buf.toArray()).toEqual([9, 10])
+  })
+})

--- a/packages/discord/src/daemon.ts
+++ b/packages/discord/src/daemon.ts
@@ -57,15 +57,16 @@ async function main() {
   }
 
   adapter.onMessage((msg) => {
-    const routed = ipc.routeInbound(msg)
+    const sessionId = ipc.routeInbound(msg)
     monitor?.recordInbound({
       channelId: msg.channelId,
       username: msg.username,
       content: msg.content,
+      sessionId: sessionId ?? undefined,
     })
     if (dbg.enabled) {
       dbg(
-        routed ? 'routed' : 'dropped (no matching session)',
+        sessionId ? 'routed' : 'dropped (no matching session)',
         `channel=${msg.channelId}`,
         `user=${msg.username}`,
         `isDM=${msg.isDM}`,

--- a/packages/discord/src/daemon.ts
+++ b/packages/discord/src/daemon.ts
@@ -36,12 +36,11 @@ async function main() {
 
   const adapter = new DiscordAdapter()
 
-  const monitorPort = process.env.MONITOR_PORT
-    ? Number.parseInt(process.env.MONITOR_PORT, 10)
-    : null
+  const rawMonitorPort = process.env.MONITOR_PORT
+  const monitorPort = rawMonitorPort ? Number.parseInt(rawMonitorPort, 10) : null
   let monitor: MonitorServer | null = null
 
-  if (monitorPort) {
+  if (monitorPort && !Number.isNaN(monitorPort)) {
     monitor = new MonitorServer(() => ({
       uptime: Math.floor((Date.now() - startedAt) / 1000),
       sessions: ipc.getSessionSnapshots(),

--- a/packages/discord/src/daemon.ts
+++ b/packages/discord/src/daemon.ts
@@ -4,6 +4,8 @@ import {
   createDebug,
   IpcServer,
   loadEnvFile,
+  MONITOR_PORT_FILE,
+  MonitorServer,
   PID_FILE,
   SOCK_PATH,
   STATE_DIR,
@@ -27,13 +29,41 @@ async function main() {
   mkdirSync(STATE_DIR, { recursive: true })
   writeFileSync(PID_FILE, String(process.pid))
 
+  const startedAt = Date.now()
+
   const ipc = new IpcServer(SOCK_PATH)
   ipc.start()
 
   const adapter = new DiscordAdapter()
 
+  // Monitor setup (optional, enabled via MONITOR_PORT env var)
+  const monitorPort = process.env.MONITOR_PORT
+    ? Number.parseInt(process.env.MONITOR_PORT, 10)
+    : null
+  let monitor: MonitorServer | null = null
+
+  if (monitorPort) {
+    monitor = new MonitorServer(() => ({
+      uptime: Math.floor((Date.now() - startedAt) / 1000),
+      sessions: ipc.getSessionSnapshots(),
+      botUsername: adapter.botUsername,
+    }))
+    try {
+      await monitor.start(monitorPort)
+      writeFileSync(MONITOR_PORT_FILE, String(monitorPort))
+      process.stderr.write(`channel-mux daemon: monitor on http://127.0.0.1:${monitorPort}\n`)
+    } catch {
+      monitor = null
+    }
+  }
+
   adapter.onMessage((msg) => {
     const routed = ipc.routeInbound(msg)
+    monitor?.recordInbound({
+      channelId: msg.channelId,
+      username: msg.username,
+      content: msg.content,
+    })
     if (dbg.enabled) {
       dbg(
         routed ? 'routed' : 'dropped (no matching session)',
@@ -46,26 +76,35 @@ async function main() {
 
   ipc.onToolCall(async (tool, args) => {
     dbg('tool_call', tool, Object.keys(args as Record<string, unknown>))
+    let result: Record<string, unknown>
     switch (tool) {
       case 'reply':
-        return adapter.reply(args as Parameters<typeof adapter.reply>[0])
-      case 'react': {
+        result = await adapter.reply(args as Parameters<typeof adapter.reply>[0])
+        break
+      case 'react':
         await adapter.react(args as Parameters<typeof adapter.react>[0])
-        return { result: 'ok' }
-      }
+        result = { result: 'ok' }
+        break
       case 'edit_message':
-        return adapter.editMessage(args as Parameters<typeof adapter.editMessage>[0])
+        result = await adapter.editMessage(args as Parameters<typeof adapter.editMessage>[0])
+        break
       case 'fetch_messages': {
-        const result = await adapter.fetchMessages(
+        const fetchResult = await adapter.fetchMessages(
           args as Parameters<typeof adapter.fetchMessages>[0],
         )
-        return { result }
+        result = { result: fetchResult }
+        break
       }
       case 'download_attachment':
-        return adapter.downloadAttachment(args as Parameters<typeof adapter.downloadAttachment>[0])
+        result = await adapter.downloadAttachment(
+          args as Parameters<typeof adapter.downloadAttachment>[0],
+        )
+        break
       default:
         throw new Error(`unknown tool: ${tool}`)
     }
+    monitor?.recordToolCall(tool, args, true)
+    return result
   })
 
   await adapter.connect(token)
@@ -75,12 +114,16 @@ async function main() {
     process.stderr.write('channel-mux daemon: shutting down\n')
     ipc.broadcastShutdown()
     ipc.stop()
+    monitor?.stop()
     adapter.disconnect()
     try {
       unlinkSync(PID_FILE)
     } catch {}
     try {
       unlinkSync(SOCK_PATH)
+    } catch {}
+    try {
+      unlinkSync(MONITOR_PORT_FILE)
     } catch {}
     process.exit(0)
   }

--- a/packages/discord/src/daemon.ts
+++ b/packages/discord/src/daemon.ts
@@ -36,7 +36,6 @@ async function main() {
 
   const adapter = new DiscordAdapter()
 
-  // Monitor setup (optional, enabled via MONITOR_PORT env var)
   const monitorPort = process.env.MONITOR_PORT
     ? Number.parseInt(process.env.MONITOR_PORT, 10)
     : null
@@ -76,35 +75,40 @@ async function main() {
 
   ipc.onToolCall(async (tool, args) => {
     dbg('tool_call', tool, Object.keys(args as Record<string, unknown>))
-    let result: Record<string, unknown>
-    switch (tool) {
-      case 'reply':
-        result = await adapter.reply(args as Parameters<typeof adapter.reply>[0])
-        break
-      case 'react':
-        await adapter.react(args as Parameters<typeof adapter.react>[0])
-        result = { result: 'ok' }
-        break
-      case 'edit_message':
-        result = await adapter.editMessage(args as Parameters<typeof adapter.editMessage>[0])
-        break
-      case 'fetch_messages': {
-        const fetchResult = await adapter.fetchMessages(
-          args as Parameters<typeof adapter.fetchMessages>[0],
-        )
-        result = { result: fetchResult }
-        break
+    try {
+      let result: Record<string, unknown>
+      switch (tool) {
+        case 'reply':
+          result = await adapter.reply(args as Parameters<typeof adapter.reply>[0])
+          break
+        case 'react':
+          await adapter.react(args as Parameters<typeof adapter.react>[0])
+          result = { result: 'ok' }
+          break
+        case 'edit_message':
+          result = await adapter.editMessage(args as Parameters<typeof adapter.editMessage>[0])
+          break
+        case 'fetch_messages': {
+          const fetchResult = await adapter.fetchMessages(
+            args as Parameters<typeof adapter.fetchMessages>[0],
+          )
+          result = { result: fetchResult }
+          break
+        }
+        case 'download_attachment':
+          result = await adapter.downloadAttachment(
+            args as Parameters<typeof adapter.downloadAttachment>[0],
+          )
+          break
+        default:
+          throw new Error(`unknown tool: ${tool}`)
       }
-      case 'download_attachment':
-        result = await adapter.downloadAttachment(
-          args as Parameters<typeof adapter.downloadAttachment>[0],
-        )
-        break
-      default:
-        throw new Error(`unknown tool: ${tool}`)
+      monitor?.recordToolCall(tool, args, true)
+      return result
+    } catch (err) {
+      monitor?.recordToolCall(tool, args, false)
+      throw err
     }
-    monitor?.recordToolCall(tool, args, true)
-    return result
   })
 
   await adapter.connect(token)


### PR DESCRIPTION
## Summary

- Add optional HTTP monitoring server to daemon, enabled via `MONITOR_PORT` env var
- Endpoints: `/status`, `/sessions`, `/requests`, `/events` (SSE)
- Binds to `127.0.0.1` only (no external access)
- Ring buffer (200 entries) for request history, content truncated to 200 chars
- `channel-mux status` shows monitor URL when active

Closes #78

## Test plan

- [x] Unit tests for RingBuffer (5 tests)
- [x] Integration tests for MonitorServer HTTP endpoints + SSE (7 tests)
- [x] IPC `getSessionSnapshots()` test
- [x] Manual: `MONITOR_PORT=9100 channel-mux start` then `curl localhost:9100/status`
- [x] Manual: verify monitor disabled when `MONITOR_PORT` not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)