### PR TITLE
docs: add architecture overview with Mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Managed via the `/channel-mux:access` skill in your Claude terminal:
 
 ## Architecture
 
+> For detailed diagrams and message flows, see the [Architecture Guide](docs/guides/architecture.md).
+
 ### IPC Protocol
 
 Daemon and plugins communicate via **JSON Lines** over a Unix domain socket.

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -93,21 +93,18 @@ sequenceDiagram
 sequenceDiagram
     participant C as Claude Code
     participant P as Plugin
-    participant IPC as IPC Server
-    participant Daemon as Daemon
+    participant Daemon as Daemon (IPC Server)
     participant A as Adapter
     participant D as Discord
 
     C->>P: call tool (reply/react/edit/fetch/download)
-    P->>IPC: tool_call { id, tool, args }
-    IPC->>Daemon: toolCallHandler(tool, args)
+    P->>Daemon: tool_call { id, tool, args }
     Daemon->>A: adapter.reply(args)
     A->>A: chunk text, load files
     A->>D: channel.send()
     D-->>A: sent message
     A-->>Daemon: { sentIds }
-    Daemon-->>IPC: tool_result { id, ok, sentIds }
-    IPC-->>P: response via socket
+    Daemon-->>P: tool_result { id, ok, sentIds }
     P-->>C: tool result
 ```
 
@@ -138,28 +135,33 @@ Session claims are exclusive: one session per channel, one session for DMs. Re-r
 
 ## Access Control (Gate)
 
+Gate logic is pure (no platform deps) in `core/gate.ts`. The Discord adapter resolves mentions and reads `access.json` before delegating to the pure function.
+
+**DM messages:**
+
 ```mermaid
-flowchart TD
-    Start([Message arrives]) --> IsDM{DM?}
-
-    IsDM -->|Yes| DmPolicy{dmPolicy}
-    DmPolicy -->|disabled| Drop([Drop])
-    DmPolicy -->|allowlist / pairing| InAllowFrom{sender in allowFrom?}
-    InAllowFrom -->|Yes| Deliver([Deliver])
-    InAllowFrom -->|No| IsAllowlist{dmPolicy = allowlist?}
-    IsAllowlist -->|Yes| Drop
-    IsAllowlist -->|No| Pair([Pair: send code])
-
-    IsDM -->|No| HasPolicy{group policy exists?}
-    HasPolicy -->|No| Drop
-    HasPolicy -->|Yes| CheckAllow{allowFrom filter?}
-    CheckAllow -->|not in list| Drop
-    CheckAllow -->|pass| NeedMention{requireMention?}
-    NeedMention -->|Yes, not mentioned| Drop
-    NeedMention -->|No / mentioned| Deliver
+flowchart LR
+    DM([DM arrives]) --> Policy{dmPolicy?}
+    Policy -->|disabled| Drop([Drop])
+    Policy -->|allowlist / pairing| Allow{sender in allowFrom?}
+    Allow -->|Yes| Deliver([Deliver])
+    Allow -->|No| Mode{dmPolicy?}
+    Mode -->|allowlist| Drop
+    Mode -->|pairing| Pair([Pair: send code])
 ```
 
-Gate logic is pure (no platform deps) in `core/gate.ts`. The Discord adapter resolves mentions and reads `access.json` before delegating to the pure function.
+**Guild messages:**
+
+```mermaid
+flowchart LR
+    Msg([Guild message]) --> Policy{group policy exists?}
+    Policy -->|No| Drop([Drop])
+    Policy -->|Yes| Allow{sender in allowFrom?}
+    Allow -->|not in list| Drop
+    Allow -->|pass| Mention{requireMention?}
+    Mention -->|Yes, not mentioned| Drop
+    Mention -->|No / mentioned| Deliver([Deliver])
+```
 
 ## State Directory
 
@@ -183,18 +185,14 @@ JSON Lines (newline-delimited JSON) over Unix domain socket.
 
 ```mermaid
 graph LR
-    subgraph "Plugin to Daemon"
-        R[register]
-        T[tool_call]
-        U[unregister]
-        PI[ping]
+    subgraph "Request / Response"
+        R[register] -->|ack| RA[register_ack]
+        T[tool_call] -->|result| TR[tool_result]
+        PI[ping] --> PO[pong]
     end
 
-    subgraph "Daemon to Plugin"
-        RA[register_ack]
+    subgraph "Daemon Push"
         I[inbound]
-        TR[tool_result]
-        PO[pong]
         S[shutdown]
     end
 ```

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -1,0 +1,212 @@
+# Architecture
+
+> Overview of the claude-channel-mux system architecture.
+
+## System Overview
+
+```mermaid
+graph TB
+    subgraph Discord
+        Bot[Discord Bot]
+    end
+
+    subgraph Daemon Process
+        Adapter[DiscordAdapter]
+        Gate[Gate Check]
+        IPC[IPC Server]
+        Monitor[Monitor Server]
+    end
+
+    subgraph Claude Code Sessions
+        P1[Plugin A]
+        P2[Plugin B]
+        P3[Plugin C]
+    end
+
+    Bot <-->|Discord.js| Adapter
+    Adapter -->|inbound msg| Gate
+    Gate -->|deliver| IPC
+    IPC <-->|Unix socket| P1
+    IPC <-->|Unix socket| P2
+    IPC <-->|Unix socket| P3
+    Monitor -.->|status query| IPC
+```
+
+The daemon holds a single Discord bot connection and multiplexes messages to multiple Claude Code sessions via Unix socket IPC. Each session runs as an MCP server plugin that connects to the daemon.
+
+## Package Dependency Graph
+
+```mermaid
+graph LR
+    CLI["@claude-channel-mux/cli<br/><small>start · stop · status</small>"]
+    Discord["@claude-channel-mux/discord<br/><small>adapter · daemon · plugin</small>"]
+    Core["@claude-channel-mux/core<br/><small>IPC · types · gate · config</small>"]
+
+    CLI --> Core
+    CLI --> Discord
+    Discord --> Core
+```
+
+| Package | Responsibility |
+|---|---|
+| **core** | Platform-agnostic: IPC protocol, types, gate logic, config paths |
+| **discord** | Platform-specific: Discord.js adapter, daemon wiring, MCP plugin |
+| **cli** | Daemon process management (start/stop/status) |
+
+## Message Flow: Inbound (Discord to Claude)
+
+```mermaid
+sequenceDiagram
+    participant D as Discord
+    participant A as Adapter
+    participant G as Gate
+    participant IPC as IPC Server
+    participant P as Plugin
+    participant C as Claude Code
+
+    D->>A: messageCreate event
+    A->>A: filter own/bot messages
+    A->>G: gate({ platform, raw })
+    G->>G: read access.json
+    G->>G: check mention / allowlist
+    G->>G: evaluateGate()
+
+    alt deliver
+        G-->>A: { action: deliver }
+        A->>A: build InboundMsg
+        A->>IPC: routeInbound(msg)
+        IPC->>IPC: lookup session by channelId or DM
+        IPC->>P: send via socket
+        P->>C: MCP notification
+    else drop
+        G-->>A: { action: drop }
+        A->>A: ignore
+    else pair
+        G-->>A: { action: pair, code }
+        A->>D: send pairing code
+    end
+```
+
+## Message Flow: Outbound (Claude to Discord)
+
+```mermaid
+sequenceDiagram
+    participant C as Claude Code
+    participant P as Plugin
+    participant IPC as IPC Server
+    participant Daemon as Daemon
+    participant A as Adapter
+    participant D as Discord
+
+    C->>P: call tool (reply/react/edit/fetch/download)
+    P->>IPC: tool_call { id, tool, args }
+    IPC->>Daemon: toolCallHandler(tool, args)
+    Daemon->>A: adapter.reply(args)
+    A->>A: chunk text, load files
+    A->>D: channel.send()
+    D-->>A: sent message
+    A-->>Daemon: { sentIds }
+    Daemon-->>IPC: tool_result { id, ok, sentIds }
+    IPC-->>P: response via socket
+    P-->>C: tool result
+```
+
+## Session Registration
+
+```mermaid
+sequenceDiagram
+    participant CC as Claude Code
+    participant P as Plugin
+    participant IPC as IPC Server
+
+    CC->>P: spawn (env: CHANNELS, HANDLE_DMS)
+    P->>IPC: connect to daemon.sock
+    P->>IPC: register { sessionId, channels, handleDMs }
+
+    alt no conflict
+        IPC->>IPC: store session, map channels
+        IPC-->>P: register_ack { ok: true, botUsername }
+        P->>P: start MCP server
+        P->>CC: ready (stdio transport)
+    else conflict
+        IPC-->>P: register_ack { ok: false, error }
+        P->>P: exit with error
+    end
+```
+
+Session claims are exclusive: one session per channel, one session for DMs. Re-registration from the same session ID releases old claims first.
+
+## Access Control (Gate)
+
+```mermaid
+flowchart TD
+    Start([Message arrives]) --> IsDM{DM?}
+
+    IsDM -->|Yes| DmPolicy{dmPolicy}
+    DmPolicy -->|disabled| Drop([Drop])
+    DmPolicy -->|allowlist / pairing| InAllowFrom{sender in allowFrom?}
+    InAllowFrom -->|Yes| Deliver([Deliver])
+    InAllowFrom -->|No| IsAllowlist{dmPolicy = allowlist?}
+    IsAllowlist -->|Yes| Drop
+    IsAllowlist -->|No| Pair([Pair: send code])
+
+    IsDM -->|No| HasPolicy{group policy exists?}
+    HasPolicy -->|No| Drop
+    HasPolicy -->|Yes| CheckAllow{allowFrom filter?}
+    CheckAllow -->|not in list| Drop
+    CheckAllow -->|pass| NeedMention{requireMention?}
+    NeedMention -->|Yes, not mentioned| Drop
+    NeedMention -->|No / mentioned| Deliver
+```
+
+Gate logic is pure (no platform deps) in `core/gate.ts`. The Discord adapter resolves mentions and reads `access.json` before delegating to the pure function.
+
+## State Directory
+
+All runtime state lives in `~/.claude/channels/channel-mux/`:
+
+```
+~/.claude/channels/channel-mux/
+  .env              Bot token (DISCORD_BOT_TOKEN)
+  access.json       Access control config
+  daemon.pid        Running daemon PID
+  daemon.sock       Unix domain socket
+  daemon.log        Daemon stderr output
+  monitor.port      Monitor server port (if enabled)
+  inbox/            Downloaded attachments
+  approved/         Pairing approval files
+```
+
+## IPC Protocol
+
+JSON Lines (newline-delimited JSON) over Unix domain socket.
+
+```mermaid
+graph LR
+    subgraph "Plugin to Daemon"
+        R[register]
+        T[tool_call]
+        U[unregister]
+        PI[ping]
+    end
+
+    subgraph "Daemon to Plugin"
+        RA[register_ack]
+        I[inbound]
+        TR[tool_result]
+        PO[pong]
+        S[shutdown]
+    end
+```
+
+| Direction | Message | Purpose |
+|---|---|---|
+| Plugin to Daemon | `register` | Claim channels, opt into DMs |
+| Plugin to Daemon | `tool_call` | Execute adapter tool (reply, react, etc.) |
+| Plugin to Daemon | `unregister` | Release claims |
+| Plugin to Daemon | `ping` | Keep-alive |
+| Daemon to Plugin | `register_ack` | Registration result + bot username |
+| Daemon to Plugin | `inbound` | Routed Discord message |
+| Daemon to Plugin | `tool_result` | Tool call response |
+| Daemon to Plugin | `pong` | Keep-alive response |
+| Daemon to Plugin | `shutdown` | Daemon shutting down |

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -165,57 +165,49 @@ flowchart LR
 
 ## State Directory
 
-All runtime state lives in `~/.claude/channels/channel-mux/`:
+All runtime state lives in `~/.claude/channels/channel-mux/`.
 
-```
-~/.claude/channels/channel-mux/
-  .env              Bot token (DISCORD_BOT_TOKEN)
-  access.json       Access control config
-  daemon.pid        Running daemon PID
-  daemon.sock       Unix domain socket
-  daemon.log        Daemon stderr output
-  monitor.port      Monitor server port (if enabled)
-  inbox/            Downloaded attachments
-  approved/         Pairing approval files
-```
+### User Config
 
 ```mermaid
 graph LR
-    subgraph Components
-        D[Daemon]
-        A[Adapter]
-        G[Gate]
-        CLI[CLI]
-        Skill[Access Skill]
-    end
-
-    subgraph State Files
-        ENV[.env]
-        ACC[access.json]
-        PID[daemon.pid]
-        SOCK[daemon.sock]
-        MON[monitor.port]
-        INB[inbox/]
-        APR[approved/]
-    end
-
-    D -->|read| ENV
-    D -->|write/delete| PID
-    D -->|write/delete| SOCK
-    D -->|write/delete| MON
-    G -->|read| ACC
-    A -->|write| INB
-    A -->|read/delete| APR
-    Skill -->|read/write| ACC
-    Skill -->|write| APR
-    CLI -->|read/delete| PID
-    CLI -->|delete| SOCK
-    CLI -->|read/delete| MON
+    ENV[.env] -->|read on startup| Daemon
+    ACC[access.json] -->|read per message| Gate
+    ACC -->|read/write| Skill[Access Skill]
 ```
 
-- **`.env`** and **`access.json`** are the only user-facing config files
-- **`approved/`** bridges the terminal skill and the daemon: the skill writes approval files, the daemon's adapter polls and consumes them
-- **`daemon.pid`**, **`daemon.sock`**, **`monitor.port`** are ephemeral process state, cleaned up on shutdown or by CLI
+| File | Description |
+|---|---|
+| `.env` | Bot token (`DISCORD_BOT_TOKEN`), monitor port, etc. |
+| `access.json` | Access control: DM policy, channel groups, allowlists |
+
+### Daemon Lifecycle
+
+```mermaid
+graph LR
+    Daemon -->|write on start| PID[daemon.pid]
+    Daemon -->|create on start| SOCK[daemon.sock]
+    Daemon -->|write if enabled| MON[monitor.port]
+    CLI -->|read / cleanup| PID
+    CLI -->|cleanup| SOCK
+    CLI -->|read / cleanup| MON
+```
+
+These are ephemeral -- created on startup, cleaned up on shutdown or by `channel-mux stop`.
+
+### Pairing Bridge
+
+```mermaid
+graph LR
+    Skill[Access Skill] -->|write approval| APR[approved/]
+    Adapter -->|poll & consume| APR
+```
+
+The `approved/` directory bridges the terminal skill and the daemon. The skill writes a file per approved user; the adapter polls and deletes it after sending confirmation.
+
+### Attachments
+
+The `inbox/` directory stores files downloaded via `download_attachment` tool. Written by the adapter, read by Claude Code sessions.
 
 ## IPC Protocol
 

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -183,28 +183,21 @@ All runtime state lives in `~/.claude/channels/channel-mux/`:
 
 JSON Lines (newline-delimited JSON) over Unix domain socket.
 
-```mermaid
-graph LR
-    subgraph "Request / Response"
-        R[register] -->|ack| RA[register_ack]
-        T[tool_call] -->|result| TR[tool_result]
-        PI[ping] --> PO[pong]
-    end
+**Plugin to Daemon:**
 
-    subgraph "Daemon Push"
-        I[inbound]
-        S[shutdown]
-    end
-```
+| Message | Purpose |
+|---|---|
+| `register` | Claim channels, opt into DMs |
+| `tool_call` | Execute adapter tool (reply, react, etc.) |
+| `unregister` | Release claims |
+| `ping` | Keep-alive |
 
-| Direction | Message | Purpose |
-|---|---|---|
-| Plugin to Daemon | `register` | Claim channels, opt into DMs |
-| Plugin to Daemon | `tool_call` | Execute adapter tool (reply, react, etc.) |
-| Plugin to Daemon | `unregister` | Release claims |
-| Plugin to Daemon | `ping` | Keep-alive |
-| Daemon to Plugin | `register_ack` | Registration result + bot username |
-| Daemon to Plugin | `inbound` | Routed Discord message |
-| Daemon to Plugin | `tool_result` | Tool call response |
-| Daemon to Plugin | `pong` | Keep-alive response |
-| Daemon to Plugin | `shutdown` | Daemon shutting down |
+**Daemon to Plugin:**
+
+| Message | Purpose |
+|---|---|
+| `register_ack` | Registration result + bot username |
+| `tool_result` | Tool call response |
+| `pong` | Keep-alive response |
+| `inbound` | Routed Discord message |
+| `shutdown` | Daemon shutting down |

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -171,9 +171,19 @@ All runtime state lives in `~/.claude/channels/channel-mux/`.
 
 ```mermaid
 graph LR
-    ENV[.env] -->|read on startup| Daemon
-    ACC[access.json] -->|read per message| Gate
-    ACC -->|read/write| Skill[Access Skill]
+    subgraph Components
+        Daemon
+        Gate
+        Skill[Access Skill]
+    end
+    subgraph Files
+        ENV[.env]
+        ACC[access.json]
+    end
+
+    ENV -->|read on startup| Daemon
+    ACC -->|read per message| Gate
+    ACC -->|read/write| Skill
 ```
 
 | File | Description |
@@ -187,31 +197,69 @@ Ephemeral files -- created on startup, cleaned up on shutdown or by `channel-mux
 
 ```mermaid
 graph LR
-    Daemon -->|start / stop| PID[daemon.pid]
-    Daemon -->|start / stop| SOCK[daemon.sock]
-    Daemon -->|start / stop| MON[monitor.port]
+    subgraph Daemon
+        D[ ]
+    end
+    subgraph Files
+        PID[daemon.pid]
+        SOCK[daemon.sock]
+        MON[monitor.port]
+    end
+
+    D -->|start / stop| PID
+    D -->|start / stop| SOCK
+    D -->|start / stop| MON
 ```
 
 ```mermaid
 graph LR
-    CLI -->|read status / cleanup| PID[daemon.pid]
-    CLI -->|cleanup| SOCK[daemon.sock]
-    CLI -->|read status / cleanup| MON[monitor.port]
+    subgraph CLI
+        C[ ]
+    end
+    subgraph Files
+        PID[daemon.pid]
+        SOCK[daemon.sock]
+        MON[monitor.port]
+    end
+
+    C -->|read status / cleanup| PID
+    C -->|cleanup| SOCK
+    C -->|read status / cleanup| MON
 ```
 
 ### Pairing Bridge
 
 ```mermaid
 graph LR
-    Skill[Access Skill] -->|write approval| APR[approved/]
-    Adapter -->|poll & consume| APR
+    subgraph Components
+        Skill[Access Skill]
+        Adapter
+    end
+    subgraph Files
+        APR[approved/]
+    end
+
+    Skill -->|write approval| APR
+    APR -->|poll & consume| Adapter
 ```
 
 The `approved/` directory bridges the terminal skill and the daemon. The skill writes a file per approved user; the adapter polls and deletes it after sending confirmation.
 
 ### Attachments
 
-The `inbox/` directory stores files downloaded via `download_attachment` tool. Written by the adapter, read by Claude Code sessions.
+```mermaid
+graph LR
+    subgraph Components
+        Adapter
+        Claude[Claude Code]
+    end
+    subgraph Files
+        INB[inbox/]
+    end
+
+    Adapter -->|download & save| INB
+    INB -->|read| Claude
+```
 
 ## IPC Protocol
 

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -179,6 +179,44 @@ All runtime state lives in `~/.claude/channels/channel-mux/`:
   approved/         Pairing approval files
 ```
 
+```mermaid
+graph LR
+    subgraph Components
+        D[Daemon]
+        A[Adapter]
+        G[Gate]
+        CLI[CLI]
+        Skill[Access Skill]
+    end
+
+    subgraph State Files
+        ENV[.env]
+        ACC[access.json]
+        PID[daemon.pid]
+        SOCK[daemon.sock]
+        MON[monitor.port]
+        INB[inbox/]
+        APR[approved/]
+    end
+
+    D -->|read| ENV
+    D -->|write/delete| PID
+    D -->|write/delete| SOCK
+    D -->|write/delete| MON
+    G -->|read| ACC
+    A -->|write| INB
+    A -->|read/delete| APR
+    Skill -->|read/write| ACC
+    Skill -->|write| APR
+    CLI -->|read/delete| PID
+    CLI -->|delete| SOCK
+    CLI -->|read/delete| MON
+```
+
+- **`.env`** and **`access.json`** are the only user-facing config files
+- **`approved/`** bridges the terminal skill and the daemon: the skill writes approval files, the daemon's adapter polls and consumes them
+- **`daemon.pid`**, **`daemon.sock`**, **`monitor.port`** are ephemeral process state, cleaned up on shutdown or by CLI
+
 ## IPC Protocol
 
 JSON Lines (newline-delimited JSON) over Unix domain socket.

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -183,17 +183,13 @@ graph LR
 
 ### Daemon Lifecycle
 
-```mermaid
-graph LR
-    Daemon -->|write on start| PID[daemon.pid]
-    Daemon -->|create on start| SOCK[daemon.sock]
-    Daemon -->|write if enabled| MON[monitor.port]
-    CLI -->|read / cleanup| PID
-    CLI -->|cleanup| SOCK
-    CLI -->|read / cleanup| MON
-```
+Ephemeral files created on startup, cleaned up on shutdown or by `channel-mux stop`.
 
-These are ephemeral -- created on startup, cleaned up on shutdown or by `channel-mux stop`.
+| File | Daemon | CLI |
+|---|---|---|
+| `daemon.pid` | write on start, delete on stop | read for status, delete on cleanup |
+| `daemon.sock` | create on start, close on stop | delete on cleanup |
+| `monitor.port` | write if enabled, delete on stop | read for status, delete on cleanup |
 
 ### Pairing Bridge
 

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -183,13 +183,21 @@ graph LR
 
 ### Daemon Lifecycle
 
-Ephemeral files created on startup, cleaned up on shutdown or by `channel-mux stop`.
+Ephemeral files -- created on startup, cleaned up on shutdown or by `channel-mux stop`.
 
-| File | Daemon | CLI |
-|---|---|---|
-| `daemon.pid` | write on start, delete on stop | read for status, delete on cleanup |
-| `daemon.sock` | create on start, close on stop | delete on cleanup |
-| `monitor.port` | write if enabled, delete on stop | read for status, delete on cleanup |
+```mermaid
+graph LR
+    Daemon -->|start / stop| PID[daemon.pid]
+    Daemon -->|start / stop| SOCK[daemon.sock]
+    Daemon -->|start / stop| MON[monitor.port]
+```
+
+```mermaid
+graph LR
+    CLI -->|read status / cleanup| PID[daemon.pid]
+    CLI -->|cleanup| SOCK[daemon.sock]
+    CLI -->|read status / cleanup| MON[monitor.port]
+```
 
 ### Pairing Bridge
 

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -11,7 +11,7 @@ graph TB
     end
 
     subgraph Daemon Process
-        Adapter[DiscordAdapter]
+        Adapter["Adapter (Discord, Slack, ...)"]
         Gate[Gate Check]
         IPC[IPC Server]
         Monitor[Monitor Server]
@@ -197,34 +197,16 @@ Ephemeral files -- created on startup, cleaned up on shutdown or by `channel-mux
 
 ```mermaid
 graph LR
-    subgraph Daemon
-        D[ ]
-    end
-    subgraph Files
-        PID[daemon.pid]
-        SOCK[daemon.sock]
-        MON[monitor.port]
-    end
-
-    D -->|start / stop| PID
-    D -->|start / stop| SOCK
-    D -->|start / stop| MON
+    Daemon -->|start / stop| PID[daemon.pid]
+    Daemon -->|start / stop| SOCK[daemon.sock]
+    Daemon -->|start / stop| MON[monitor.port]
 ```
 
 ```mermaid
 graph LR
-    subgraph CLI
-        C[ ]
-    end
-    subgraph Files
-        PID[daemon.pid]
-        SOCK[daemon.sock]
-        MON[monitor.port]
-    end
-
-    C -->|read status / cleanup| PID
-    C -->|cleanup| SOCK
-    C -->|read status / cleanup| MON
+    CLI -->|read status / cleanup| PID[daemon.pid]
+    CLI -->|cleanup| SOCK[daemon.sock]
+    CLI -->|read status / cleanup| MON[monitor.port]
 ```
 
 ### Pairing Bridge
@@ -233,14 +215,14 @@ graph LR
 graph LR
     subgraph Components
         Skill[Access Skill]
-        Adapter
+        Adp["Adapter (Discord, Slack, ...)"]
     end
     subgraph Files
         APR[approved/]
     end
 
     Skill -->|write approval| APR
-    APR -->|poll & consume| Adapter
+    APR -->|poll & consume| Adp
 ```
 
 The `approved/` directory bridges the terminal skill and the daemon. The skill writes a file per approved user; the adapter polls and deletes it after sending confirmation.
@@ -250,14 +232,14 @@ The `approved/` directory bridges the terminal skill and the daemon. The skill w
 ```mermaid
 graph LR
     subgraph Components
-        Adapter
+        Adp["Adapter (Discord, Slack, ...)"]
         Claude[Claude Code]
     end
     subgraph Files
         INB[inbox/]
     end
 
-    Adapter -->|download & save| INB
+    Adp -->|download & save| INB
     INB -->|read| Claude
 ```
 


### PR DESCRIPTION
## Summary

- System overview, package dependency graph, message flows, session registration, access control, IPC protocol
- All diagrams in Mermaid (GitHub native rendering)
- Located at `docs/guides/architecture.md`

Closes #82

## Test plan

- [ ] Verify Mermaid diagrams render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)