### PR TITLE
fix: exclude settings.local.json from biome checks

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -27,6 +27,13 @@
     }
   },
   "files": {
-    "includes": ["**", "!**/dist", "!**/node_modules", "!**/pnpm-lock.yaml", "!**/CHANGELOG.md"]
+    "includes": [
+      "**",
+      "!**/dist",
+      "!**/node_modules",
+      "!**/pnpm-lock.yaml",
+      "!**/CHANGELOG.md",
+      "!.claude/settings.local.json"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Add `.claude/settings.local.json` to biome ignore list
- Reformat `files.includes` array for line length compliance

This file is already gitignored but was causing local lint failures.

## Test plan
- [x] `pnpm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)