### PR TITLE
feat: add .mcp.json to discord plugin package

### DIFF
--- a/packages/discord/.mcp.json
+++ b/packages/discord/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "channel-mux": {
+      "command": "node",
+      "args": ["dist/plugin.mjs"]
+    }
+  }
+}

--- a/packages/discord/package.json
+++ b/packages/discord/package.json
@@ -36,7 +36,8 @@
   "files": [
     "dist",
     "skills",
-    ".claude-plugin"
+    ".claude-plugin",
+    ".mcp.json"
   ],
   "scripts": {
     "build": "tsdown",

--- a/tests/smoke/smoke.test.ts
+++ b/tests/smoke/smoke.test.ts
@@ -60,12 +60,13 @@ describe('smoke tests', () => {
     expect(distFiles.some((f) => f.includes('index.d.mts'))).toBe(true)
   })
 
-  it('discord tarball contains dist/, skills/, .claude-plugin/', () => {
+  it('discord tarball contains dist/, skills/, .claude-plugin/, .mcp.json', () => {
     const pkgRoot = extractTarball('discord')
     const contents = readdirSync(pkgRoot)
     expect(contents).toContain('dist')
     expect(contents).toContain('skills')
     expect(contents).toContain('.claude-plugin')
+    expect(contents).toContain('.mcp.json')
   })
 
   it('cli tarball contains dist/ with cli.mjs', () => {


### PR DESCRIPTION
## Summary
- Add `.mcp.json` to `packages/discord/` (plugin root, not monorepo root)
- Include `.mcp.json` in `files` array so it ships with `pnpm publish`
- Add smoke test assertion to verify `.mcp.json` is in the tarball

Previously `.mcp.json` was mistakenly placed at the monorepo root, which meant it wouldn't be included in the published package.

## Test plan
Smoke test (`pnpm pack` → tarball extraction) now asserts `.mcp.json` is present in the discord package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)