### PR TITLE
docs: revamp quickstart and plugin installation guides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ pnpm workspace monorepo with three packages:
 packages/
   core/       @claude-channel-mux/core      IPC, types, gate, config
   discord/    @claude-channel-mux/discord    Discord adapter, daemon, plugin
-  cli/        @claude-channel-mux/cli        CLI (start/stop/status)
+  cli/        @claude-channel-mux/cli        CLI (daemon, session)
 ```
 
 ### Dependency graph
@@ -73,7 +73,7 @@ core -> (no internal deps)
 - `plugin.ts`: MCP server with 5 tools, IPC-proxied to daemon
 
 ### packages/cli
-- `cli.ts`: start/stop/status commands, daemon process management
+- `cli.ts`: `channel-mux daemon` (start/stop/status/group) and `channel-mux session` (view/channels/dms)
 
 ## Coding Conventions
 
@@ -122,8 +122,8 @@ JSON Lines (newline-delimited JSON) over Unix domain socket at `~/.claude/channe
 ## Key Design Decisions
 
 - **Gate logic separated from adapters**: Core `evaluateGate()` operates on plain data. Discord adapter extracts fields from discord.js Message, resolves mentions, then delegates to core. This enables testing without mocking and reuse across adapters.
-- **Plugin does NOT auto-start daemon**. User must start manually via `channel-mux start`.
+- **Plugin does NOT auto-start daemon**. User must start manually via `channel-mux daemon start`.
 - **One bot token per daemon**. Multi-bot not supported in v1.
 - **Unix socket only**. Windows native not supported (WSL works).
-- **Access mutations only via terminal skill**, never from channel messages (prompt injection defense).
+- **Access mutations only via terminal skill or CLI**, never from channel messages (prompt injection defense).
 - **workspace:* protocol**: pnpm resolves to actual versions at publish time. CI uses `pnpm publish` (not npm) to ensure resolution.

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ echo "DISCORD_BOT_TOKEN=your_token_here" > ~/.claude/channels/channel-mux/.env
 ### 4. Start the daemon
 
 ```bash
-channel-mux start
-channel-mux status   # verify it's running
+channel-mux daemon start
+channel-mux daemon status   # verify it's running
 ```
 
 ### 5. Install the plugin
@@ -90,20 +90,30 @@ In a Claude Code session, install the plugin from the custom marketplace:
 
 The plugin ships with `.mcp.json`, so the MCP server is configured automatically.
 
-### 6. Start Claude Code with channels enabled
+### 6. Configure channels
 
-The simplest way is to pass the channel ID and DM handling as environment variables:
+Add channels to the daemon and configure session routing:
 
 ```bash
-CHANNEL_MUX_CHANNELS=YOUR_CHANNEL_ID CHANNEL_MUX_HANDLE_DMS=true \
-  claude --dangerously-load-development-channels server:channel-mux
+# Allow the daemon to receive from your channel
+channel-mux daemon group add YOUR_CHANNEL_ID
+
+# Set which channels this session routes (writes to .mcp.json)
+channel-mux session channels YOUR_CHANNEL_ID
+channel-mux session dms true
 ```
 
-> You can also set these in `.mcp.json` (project-level or `~/.claude/.mcp.json`) env block. See the [Plugin Installation Guide](docs/guides/plugin-install.md) for details.
+> **Tip**: Get a channel ID by enabling Developer Mode in Discord settings, then right-clicking a channel > "Copy Channel ID". Multiple IDs can be space-separated.
+
+### 7. Start Claude Code with channels enabled
+
+```bash
+claude --dangerously-load-development-channels server:channel-mux
+```
 
 > **Warning**: The `--dangerously-load-development-channels` flag loads channel plugins that are NOT from the official Anthropic marketplace. Only official Anthropic channels can run without this flag. Do not use this flag if you do not understand what it does -- it allows third-party code to inject messages into your Claude session.
 
-### 7. Start chatting
+### 8. Start chatting
 
 Send a DM to your bot. It will respond with a pairing code. In your terminal:
 
@@ -113,15 +123,24 @@ Send a DM to your bot. It will respond with a pairing code. In your terminal:
 
 You're paired. Messages now flow to your Claude session.
 
-> **Tip**: Get a channel ID by enabling Developer Mode in Discord settings, then right-clicking a channel > "Copy Channel ID".
-
 ## CLI Reference
 
 ```bash
-channel-mux start    # Start daemon in background
-channel-mux stop     # Stop daemon (SIGTERM -> SIGKILL)
-channel-mux status   # Check if daemon is running
+# Daemon management
+channel-mux daemon start [--verbose]   # Start daemon in background
+channel-mux daemon stop                # Stop daemon (SIGTERM -> SIGKILL)
+channel-mux daemon status              # Check if daemon is running
+channel-mux daemon group add <id> ...  # Add channels to daemon reception
+channel-mux daemon group rm <id> ...   # Remove channels
+channel-mux daemon group list          # List configured channels
+
+# Session routing
+channel-mux session                            # View current config
+channel-mux session channels <id> [...]        # Set channel IDs
+channel-mux session dms <true|false>           # Set DM handling
 ```
+
+> `session channels` and `session dms` accept `--scope=local|project|user` to choose which `.mcp.json` to write (default: `local`).
 
 ## Configuration
 
@@ -229,7 +248,7 @@ packages/
       utils.ts           # chunk(), assertSendable(), safeAttName()
   cli/                 @claude-channel-mux/cli
     src/
-      cli.ts             # CLI (start/stop/status)
+      cli.ts             # CLI (daemon, session)
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -98,12 +98,14 @@ Add channels to the daemon and configure session routing:
 # Allow the daemon to receive from your channel
 channel-mux daemon group add YOUR_CHANNEL_ID
 
-# Set which channels this session routes (writes to .mcp.json)
+# Set which channels this session routes (updates .mcp.json env block)
 channel-mux session channels YOUR_CHANNEL_ID
 channel-mux session dms true
 ```
 
 > **Tip**: Get a channel ID by enabling Developer Mode in Discord settings, then right-clicking a channel > "Copy Channel ID". Multiple IDs can be space-separated.
+>
+> **Note**: If you installed via the plugin marketplace (step 5), the plugin provides a default `.mcp.json`. Running `session channels` / `session dms` updates the env block in your local `.mcp.json`, which takes precedence.
 
 ### 7. Start Claude Code with channels enabled
 

--- a/README.md
+++ b/README.md
@@ -42,35 +42,7 @@ The official Claude Code Discord plugin spawns a dedicated bot per session. That
 ## Prerequisites
 
 - **Node.js** >= 20
-- **pnpm** (workspace-enabled package manager)
 - A **Discord bot** with Message Content Intent enabled
-
-## Installation
-
-### From source (current)
-
-```bash
-git clone https://github.com/HealGaren/claude-channel-mux.git
-cd claude-channel-mux
-pnpm install
-pnpm run build
-```
-
-This is a pnpm workspace monorepo. `pnpm install` at the root installs all
-workspace packages and links their internal dependencies.
-
-### From npm registry
-
-```bash
-# npm
-npm install -g @claude-channel-mux/cli
-
-# pnpm
-pnpm add -g @claude-channel-mux/cli
-
-# yarn
-yarn global add @claude-channel-mux/cli
-```
 
 ## Quick Start
 
@@ -83,64 +55,55 @@ See the [Discord Setup Guide](docs/guides/discord-setup.md) for detailed instruc
 3. **OAuth2 > URL Generator**: scope `bot`, permissions: Send Messages, Read Message History, Add Reactions, Attach Files
 4. Invite the bot to your server with the generated URL
 
-### 2. Configure
+### 2. Install
 
 ```bash
-mkdir -p ~/.claude/channels/channel-mux
-cat > ~/.claude/channels/channel-mux/.env << 'EOF'
-DISCORD_BOT_TOKEN=your_token_here
-EOF
+npm install -g @claude-channel-mux/cli
 ```
 
-### 3. Start the daemon
+### 3. Configure bot token
 
 ```bash
-# Foreground (see logs directly)
-pnpm run dev
+echo "DISCORD_BOT_TOKEN=your_token_here" > ~/.claude/channels/channel-mux/.env
+```
 
-# Or background via CLI
+> The state directory (`~/.claude/channels/channel-mux/`) is created automatically on first daemon start.
+
+### 4. Start the daemon
+
+```bash
 channel-mux start
-channel-mux status
+channel-mux status   # verify it's running
 ```
 
-### 4. Connect Claude Code
+### 5. Install the plugin
 
-Add to your `.mcp.json` (project-level or `~/.claude/.mcp.json`). See the [Plugin Installation Guide](docs/guides/plugin-install.md) for all options (dev mode, npm, marketplace) or the [MCP Configuration Guide](docs/guides/mcp-config.md) for details.
+In a Claude Code session, install the plugin from the custom marketplace:
 
-```json
-{
-  "mcpServers": {
-    "channel-mux": {
-      "command": "channel-mux-plugin",
-      "env": {
-        "CHANNEL_MUX_CHANNELS": "YOUR_CHANNEL_ID",
-        "CHANNEL_MUX_HANDLE_DMS": "true"
-      }
-    }
-  }
-}
+```bash
+# Add the marketplace (one-time)
+/plugins marketplace add HealGaren/claude-channel-mux
+
+# Install the plugin
+/plugins install channel-mux@HealGaren/claude-channel-mux
 ```
 
-If running from the monorepo source with tsx:
+The plugin ships with `.mcp.json`, so the MCP server is configured automatically.
 
-```json
-{
-  "mcpServers": {
-    "channel-mux": {
-      "command": "npx",
-      "args": ["tsx", "packages/discord/src/plugin.ts"],
-      "env": {
-        "CHANNEL_MUX_CHANNELS": "YOUR_CHANNEL_ID",
-        "CHANNEL_MUX_HANDLE_DMS": "true"
-      }
-    }
-  }
-}
+### 6. Start Claude Code with channels enabled
+
+The simplest way is to pass the channel ID and DM handling as environment variables:
+
+```bash
+CHANNEL_MUX_CHANNELS=YOUR_CHANNEL_ID CHANNEL_MUX_HANDLE_DMS=true \
+  claude --dangerously-load-development-channels server:channel-mux
 ```
 
-> **Tip**: Get a channel ID by enabling Developer Mode in Discord settings, then right-clicking a channel -> "Copy Channel ID". Separate multiple channels with commas.
+> You can also set these in `.mcp.json` (project-level or `~/.claude/.mcp.json`) env block. See the [Plugin Installation Guide](docs/guides/plugin-install.md) for details.
 
-### 5. Start chatting
+> **Warning**: The `--dangerously-load-development-channels` flag loads channel plugins that are NOT from the official Anthropic marketplace. Only official Anthropic channels can run without this flag. Do not use this flag if you do not understand what it does -- it allows third-party code to inject messages into your Claude session.
+
+### 7. Start chatting
 
 Send a DM to your bot. It will respond with a pairing code. In your terminal:
 
@@ -149,6 +112,8 @@ Send a DM to your bot. It will respond with a pairing code. In your terminal:
 ```
 
 You're paired. Messages now flow to your Claude session.
+
+> **Tip**: Get a channel ID by enabling Developer Mode in Discord settings, then right-clicking a channel > "Copy Channel ID".
 
 ## CLI Reference
 
@@ -225,6 +190,25 @@ interface PlatformAdapter {
 - **Outbound gate** -- bot can only send to channels listed in `access.json`
 - **File path security** -- `assertSendable()` blocks sending state directory files (except inbox)
 - **Attachment sanitization** -- filenames are stripped of injection characters
+
+## Monitoring
+
+The daemon has an optional HTTP monitoring server for observing runtime state. Set `MONITOR_PORT` in your `.env`:
+
+```
+MONITOR_PORT=9100
+```
+
+Endpoints (bound to `127.0.0.1` only):
+
+| Endpoint | Description |
+|---|---|
+| `GET /status` | Daemon uptime, session count, bot username |
+| `GET /sessions` | Connected sessions with claimed channels |
+| `GET /requests` | Recent request log (last 200 entries) |
+| `GET /events` | SSE stream (inbound, tool_call, session connect/disconnect) |
+
+See the [Monitor API Guide](docs/guides/monitor-api.md) for full response schemas.
 
 ## Project Structure
 

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -193,7 +193,7 @@ graph LR
 
 ### Daemon Lifecycle
 
-Ephemeral files -- created on startup, cleaned up on shutdown or by `channel-mux stop`.
+Ephemeral files -- created on startup, cleaned up on shutdown or by `channel-mux daemon stop`.
 
 ```mermaid
 graph LR

--- a/docs/guides/mcp-config.md
+++ b/docs/guides/mcp-config.md
@@ -4,7 +4,7 @@ This guide explains how to manually connect claude-channel-mux to Claude Code vi
 
 > **Recommended**: Install via the [plugin marketplace](./plugin-install.md#install-from-marketplace-recommended) instead. The plugin ships with `.mcp.json` pre-configured, so manual setup is not needed. This guide is for cases where you need custom MCP configuration or are installing from source.
 >
-> **Important**: `.mcp.json` alone only enables MCP tools (reply, react, etc.). For channel messages to flow from Discord into your Claude session, you must also start Claude Code with `--dangerously-load-development-channels server:channel-mux`. The plugin marketplace handles this automatically.
+> **Important**: `.mcp.json` alone only enables MCP tools (reply, react, etc.). For channel messages to flow from Discord into your Claude session, you must also start Claude Code with `--dangerously-load-development-channels server:channel-mux`. The plugin marketplace simplifies setup but you still need this flag.
 
 ## Prerequisites
 

--- a/docs/guides/mcp-config.md
+++ b/docs/guides/mcp-config.md
@@ -3,6 +3,8 @@
 This guide explains how to manually connect claude-channel-mux to Claude Code via `.mcp.json`.
 
 > **Recommended**: Install via the [plugin marketplace](./plugin-install.md#install-from-marketplace-recommended) instead. The plugin ships with `.mcp.json` pre-configured, so manual setup is not needed. This guide is for cases where you need custom MCP configuration or are installing from source.
+>
+> **Important**: `.mcp.json` alone only enables MCP tools (reply, react, etc.). For channel messages to flow from Discord into your Claude session, you must also start Claude Code with `--dangerously-load-development-channels server:channel-mux`. The plugin marketplace handles this automatically.
 
 ## Prerequisites
 

--- a/docs/guides/mcp-config.md
+++ b/docs/guides/mcp-config.md
@@ -6,7 +6,7 @@ This guide explains how to connect claude-channel-mux to Claude Code via `.mcp.j
 
 - Discord bot set up and token configured (see [Discord Setup Guide](./discord-setup.md))
 - `@claude-channel-mux/cli` and `@claude-channel-mux/discord` installed
-- Daemon running (`channel-mux start`)
+- Daemon running (`channel-mux daemon start`)
 
 ## Configuration File
 
@@ -80,7 +80,7 @@ Only one session can handle DMs at a time. Channel IDs cannot overlap between se
 
 ## Verifying the Connection
 
-1. Start the daemon: `channel-mux start`
+1. Start the daemon: `channel-mux daemon start`
 2. Start a Claude Code session with the `.mcp.json` configured
 3. Check daemon logs: `tail -f ~/.claude/channels/channel-mux/daemon.log`
 4. You should see: `channel-mux ipc: session <id> registered`
@@ -88,8 +88,8 @@ Only one session can handle DMs at a time. Channel IDs cannot overlap between se
 ## Troubleshooting
 
 ### "cannot connect to daemon"
-- Start the daemon first: `channel-mux start`
-- Check status: `channel-mux status`
+- Start the daemon first: `channel-mux daemon start`
+- Check status: `channel-mux daemon status`
 
 ### "channel already claimed by another session"
 - Another Claude Code session has already claimed that channel

--- a/docs/guides/mcp-config.md
+++ b/docs/guides/mcp-config.md
@@ -1,6 +1,8 @@
 # MCP Configuration Guide
 
-This guide explains how to connect claude-channel-mux to Claude Code via `.mcp.json`.
+This guide explains how to manually connect claude-channel-mux to Claude Code via `.mcp.json`.
+
+> **Recommended**: Install via the [plugin marketplace](./plugin-install.md#install-from-marketplace-recommended) instead. The plugin ships with `.mcp.json` pre-configured, so manual setup is not needed. This guide is for cases where you need custom MCP configuration or are installing from source.
 
 ## Prerequisites
 

--- a/docs/guides/plugin-install.md
+++ b/docs/guides/plugin-install.md
@@ -64,115 +64,27 @@ claude --dangerously-load-development-channels server:channel-mux
 
 If you prefer to configure the MCP server manually instead of using the plugin marketplace:
 
-### 1. Install the package
-
-```bash
-npm install -g @claude-channel-mux/cli
-```
-
-### 2. Configure .mcp.json
-
-Add to your `.mcp.json` (project-level or `~/.claude/.mcp.json`):
-
-```json
-{
-  "mcpServers": {
-    "channel-mux": {
-      "command": "channel-mux-plugin",
-      "env": {
-        "CHANNEL_MUX_CHANNELS": "YOUR_CHANNEL_ID",
-        "CHANNEL_MUX_HANDLE_DMS": "true"
-      }
-    }
-  }
-}
-```
-
-Replace `YOUR_CHANNEL_ID` with your Discord channel ID (see [Discord Setup Guide](./discord-setup.md#7-get-channel-ids)).
-
-### 3. Start Claude Code with channels enabled
-
-```bash
-claude --dangerously-load-development-channels server:channel-mux
-```
+1. Install: `npm install -g @claude-channel-mux/cli`
+2. Configure MCP server: see [MCP Configuration Guide](./mcp-config.md) for `.mcp.json` setup
+3. Configure channels: `channel-mux daemon group add <channelId>` and `channel-mux session channels <channelId>`
+4. Start Claude Code: `claude --dangerously-load-development-channels server:channel-mux`
 
 ## Install from source (for development)
 
 For contributors or testing unreleased changes.
 
-### 1. Clone and build
-
-```bash
-git clone git@github.com:HealGaren/claude-channel-mux.git
-cd claude-channel-mux
-pnpm install
-pnpm run build
-```
-
-### 2. Start the daemon
-
-```bash
-pnpm run dev          # foreground with watch mode
-# or
-node packages/cli/dist/cli.mjs daemon start   # background
-```
-
-### 3. Configure .mcp.json
-
-```json
-{
-  "mcpServers": {
-    "channel-mux": {
-      "command": "node",
-      "args": ["/path/to/claude-channel-mux/packages/discord/dist/plugin.mjs"],
-      "env": {
-        "CHANNEL_MUX_CHANNELS": "YOUR_CHANNEL_ID",
-        "CHANNEL_MUX_HANDLE_DMS": "true"
-      }
-    }
-  }
-}
-```
-
-Or with tsx (direct TypeScript execution):
-
-```json
-{
-  "mcpServers": {
-    "channel-mux": {
-      "command": "npx",
-      "args": ["tsx", "/path/to/claude-channel-mux/packages/discord/src/plugin.ts"],
-      "env": {
-        "CHANNEL_MUX_CHANNELS": "YOUR_CHANNEL_ID",
-        "CHANNEL_MUX_HANDLE_DMS": "true"
-      }
-    }
-  }
-}
-```
-
-### 4. Start Claude Code
-
-```bash
-claude --dangerously-load-development-channels server:channel-mux
-```
-
-Or load it as a plugin directory:
-
-```bash
-claude --plugin-dir ./packages/discord --dangerously-load-development-channels plugin:channel-mux
-```
-
-### 5. Reload after changes
-
-```bash
-pnpm run build
-```
-
-Then in Claude Code:
-```
-/reload-plugins
-```
+1. Clone and build:
+   ```bash
+   git clone git@github.com:HealGaren/claude-channel-mux.git
+   cd claude-channel-mux
+   pnpm install
+   pnpm run build
+   ```
+2. Start the daemon: `pnpm run dev` (foreground) or `node packages/cli/dist/cli.mjs daemon start` (background)
+3. Configure MCP server: see [MCP Configuration Guide](./mcp-config.md) for `.mcp.json` setup (use "Local install" section)
+4. Start Claude Code: `claude --dangerously-load-development-channels server:channel-mux`
+   - Or as plugin directory: `claude --plugin-dir ./packages/discord --dangerously-load-development-channels plugin:channel-mux`
+5. After code changes: `pnpm run build` then `/reload-plugins` in Claude Code
 
 ## First conversation (DM pairing)
 

--- a/docs/guides/plugin-install.md
+++ b/docs/guides/plugin-install.md
@@ -10,7 +10,7 @@ How to install and use claude-channel-mux as a Claude Code channel plugin.
 - claude.ai account (Console/API key auth not supported for channels)
 - Discord bot set up (see [Discord Setup Guide](./discord-setup.md))
 - Bot token configured (`~/.claude/channels/channel-mux/.env`)
-- Daemon running (`channel-mux start`)
+- Daemon running (`channel-mux daemon start`)
 
 ## Install from marketplace (recommended)
 
@@ -30,22 +30,30 @@ In your Claude Code terminal:
 
 The plugin ships with `.mcp.json`, so the MCP server is configured automatically.
 
-### 2. Start Claude Code with channels enabled
-
-Pass channel configuration as environment variables and start Claude Code:
+### 2. Configure channels
 
 ```bash
-CHANNEL_MUX_CHANNELS=YOUR_CHANNEL_ID CHANNEL_MUX_HANDLE_DMS=true \
-  claude --dangerously-load-development-channels server:channel-mux
+# Allow the daemon to receive from your channel
+channel-mux daemon group add YOUR_CHANNEL_ID
+
+# Set which channels this session routes
+channel-mux session channels YOUR_CHANNEL_ID
+channel-mux session dms true
+```
+
+> `channel-mux session` writes to `.mcp.json`. Use `--scope=local|project|user` to choose which file (default: `local`).
+
+### 3. Start Claude Code with channels enabled
+
+```bash
+claude --dangerously-load-development-channels server:channel-mux
 ```
 
 > `server:channel-mux` refers to the MCP server name defined in the plugin's `.mcp.json`.
 
-You can also set these variables permanently in `.mcp.json` (project-level or `~/.claude/.mcp.json`) under the `env` block. See the [MCP Configuration Guide](./mcp-config.md) for details.
-
 > **Warning**: The `--dangerously-load-development-channels` flag loads channel plugins that are NOT from the official Anthropic marketplace. Only official Anthropic channels can run without this flag. This flag allows third-party code to inject messages into your Claude session. Do not use it if you do not understand the implications.
 
-### 3. Verify the connection
+### 4. Verify the connection
 
 1. Check daemon logs: `tail -f ~/.claude/channels/channel-mux/daemon.log`
 2. You should see: `channel-mux ipc: session <id> registered`
@@ -106,7 +114,7 @@ pnpm run build
 ```bash
 pnpm run dev          # foreground with watch mode
 # or
-node packages/cli/dist/cli.mjs start   # background
+node packages/cli/dist/cli.mjs daemon start   # background
 ```
 
 ### 3. Configure .mcp.json
@@ -190,7 +198,7 @@ You started Claude Code without `--channels` or `--dangerously-load-development-
 ### "cannot connect to daemon"
 The daemon isn't running. Start it:
 ```bash
-channel-mux start
+channel-mux daemon start
 ```
 
 ### "channel already claimed by another session"

--- a/docs/guides/plugin-install.md
+++ b/docs/guides/plugin-install.md
@@ -10,32 +10,59 @@ How to install and use claude-channel-mux as a Claude Code channel plugin.
 - claude.ai account (Console/API key auth not supported for channels)
 - Discord bot set up (see [Discord Setup Guide](./discord-setup.md))
 - Bot token configured (`~/.claude/channels/channel-mux/.env`)
+- Daemon running (`channel-mux start`)
 
-## Install from npm
+## Install from marketplace (recommended)
+
+The plugin is available through a custom marketplace.
+
+### 1. Add the marketplace and install
+
+In your Claude Code terminal:
+
+```bash
+# Add the marketplace (one-time)
+/plugins marketplace add HealGaren/claude-channel-mux
+
+# Install the plugin
+/plugins install channel-mux@HealGaren/claude-channel-mux
+```
+
+The plugin ships with `.mcp.json`, so the MCP server is configured automatically.
+
+### 2. Start Claude Code with channels enabled
+
+Pass channel configuration as environment variables and start Claude Code:
+
+```bash
+CHANNEL_MUX_CHANNELS=YOUR_CHANNEL_ID CHANNEL_MUX_HANDLE_DMS=true \
+  claude --dangerously-load-development-channels server:channel-mux
+```
+
+> `server:channel-mux` refers to the MCP server name defined in the plugin's `.mcp.json`.
+
+You can also set these variables permanently in `.mcp.json` (project-level or `~/.claude/.mcp.json`) under the `env` block. See the [MCP Configuration Guide](./mcp-config.md) for details.
+
+> **Warning**: The `--dangerously-load-development-channels` flag loads channel plugins that are NOT from the official Anthropic marketplace. Only official Anthropic channels can run without this flag. This flag allows third-party code to inject messages into your Claude session. Do not use it if you do not understand the implications.
+
+### 3. Verify the connection
+
+1. Check daemon logs: `tail -f ~/.claude/channels/channel-mux/daemon.log`
+2. You should see: `channel-mux ipc: session <id> registered`
+3. Send a message in your configured Discord channel or DM the bot
+4. The message should appear in your Claude Code session as a `<channel>` tag
+
+## Install from npm (manual MCP setup)
+
+If you prefer to configure the MCP server manually instead of using the plugin marketplace:
 
 ### 1. Install the package
 
 ```bash
-# npm
 npm install -g @claude-channel-mux/cli
-
-# pnpm
-pnpm add -g @claude-channel-mux/cli
-
-# yarn
-yarn global add @claude-channel-mux/cli
 ```
 
-This also installs `@claude-channel-mux/discord` as a dependency.
-
-### 2. Start the daemon
-
-```bash
-channel-mux start
-channel-mux status   # verify it's running
-```
-
-### 3. Configure .mcp.json
+### 2. Configure .mcp.json
 
 Add to your `.mcp.json` (project-level or `~/.claude/.mcp.json`):
 
@@ -55,49 +82,11 @@ Add to your `.mcp.json` (project-level or `~/.claude/.mcp.json`):
 
 Replace `YOUR_CHANNEL_ID` with your Discord channel ID (see [Discord Setup Guide](./discord-setup.md#7-get-channel-ids)).
 
-### 4. Start Claude Code with channels enabled
-
-The `.mcp.json` alone connects the MCP server and its tools, but **channel messages (push events from Discord) only arrive when you enable channels** with the `--channels` flag.
-
-During the research preview, custom channels need the development flag:
+### 3. Start Claude Code with channels enabled
 
 ```bash
 claude --dangerously-load-development-channels server:channel-mux
 ```
-
-> `server:channel-mux` refers to the server name in your `.mcp.json` (`"channel-mux"`).
-
-Once the project marketplace is set up, this will become:
-
-```bash
-claude --channels plugin:channel-mux@HealGaren/claude-channel-mux
-```
-
-### 5. Verify the connection
-
-1. Check daemon logs: `tail -f ~/.claude/channels/channel-mux/daemon.log`
-2. You should see: `channel-mux ipc: session <id> registered`
-3. Send a message in your configured Discord channel or DM the bot
-4. The message should appear in your Claude Code session as a `<channel>` tag
-
-## Install from marketplace (planned)
-
-A project marketplace will be published so users can install with:
-
-```bash
-# Add the marketplace (one-time)
-/plugin marketplace add HealGaren/claude-channel-mux
-
-# Install the plugin
-/plugin install channel-mux@HealGaren/claude-channel-mux
-
-# Start with channel enabled
-claude --channels plugin:channel-mux@HealGaren/claude-channel-mux
-```
-
-Not available yet. See the [project roadmap](https://github.com/HealGaren/claude-channel-mux/issues/1).
-
-> **Note**: This plugin connects to external services (Discord) and injects external messages into Claude sessions. Due to security considerations, it is distributed through a project marketplace rather than the official Anthropic marketplace.
 
 ## Install from source (for development)
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,9 +13,10 @@ npm install -g @claude-channel-mux/cli
 ## Usage
 
 ```bash
-channel-mux start    # Start daemon in background
-channel-mux stop     # Stop daemon (SIGTERM, then SIGKILL)
-channel-mux status   # Check if daemon is running
+channel-mux daemon start    # Start daemon in background
+channel-mux daemon stop     # Stop daemon (SIGTERM, then SIGKILL)
+channel-mux daemon status   # Check if daemon is running
+channel-mux session         # View session routing config
 ```
 
 ## Note


### PR DESCRIPTION
## Summary
- Restructure README Quick Start: plugin marketplace install as primary flow
- Add channel config step using CLI: \`daemon group add\` + \`session channels/dms\`
- Update all CLI references to new \`channel-mux daemon\` namespace across all docs
- Update plugin-install.md: marketplace is available now (was "planned"), deduplicate MCP config into mcp-config.md link
- Add Monitor API section to README with endpoint summary
- Update CLAUDE.md: CLI description, design decisions
- Add plugin marketplace recommendation and channel push limitation note to mcp-config.md
- Update architecture.md, cli/README.md for new CLI structure
- Add \`--dangerously-load-development-channels\` security warning
- Remove \`pnpm\` from Prerequisites (not needed for users)

Files changed: README.md, CLAUDE.md, docs/guides/plugin-install.md, docs/guides/mcp-config.md, docs/guides/architecture.md, packages/cli/README.md

## Test plan
Documentation-only changes. Verify rendered markdown on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)