### PR TITLE
fix: run biome format after version sync in release hook

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -12,7 +12,7 @@
   },
   "hooks": {
     "before:init": ["pnpm run build", "pnpm run typecheck", "pnpm test"],
-    "after:bump": "npx tsx scripts/sync-versions.ts"
+    "after:bump": "npx tsx scripts/sync-versions.ts && pnpm run format"
   },
   "plugins": {
     "@release-it/conventional-changelog": {

--- a/packages/discord/.claude-plugin/plugin.json
+++ b/packages/discord/.claude-plugin/plugin.json
@@ -5,9 +5,7 @@
   "mcpServers": {
     "channel-mux": {
       "command": "node",
-      "args": [
-        "${CLAUDE_PLUGIN_ROOT}/dist/plugin.mjs"
-      ],
+      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/plugin.mjs"],
       "env": {
         "CHANNEL_MUX_HANDLE_DMS": "true"
       }


### PR DESCRIPTION
## Summary
- Add `pnpm run format` after `sync-versions.ts` in release-it after:bump hook
- Fix current plugin.json formatting broken by 0.1.1-alpha.1 release

`sync-versions.ts` uses `JSON.stringify(obj, null, 2)` which expands short arrays to multiline, breaking biome's formatting rules. This caused CI lint to fail on every release commit.

## Test plan
- `pnpm run lint` passes after release bump
- Next release should not break CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)