### PR TITLE
fix: add version to marketplace.json and sync on release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,8 @@
       "name": "channel-mux",
       "source": {
         "source": "npm",
-        "package": "@claude-channel-mux/discord"
+        "package": "@claude-channel-mux/discord",
+        "version": "0.1.2"
       },
       "description": "Discord channel multiplexer for Claude Code -- routes messages from a shared bot to multiple sessions"
     }

--- a/scripts/sync-versions.ts
+++ b/scripts/sync-versions.ts
@@ -31,3 +31,14 @@ const pluginJson = JSON.parse(readFileSync(pluginJsonPath, 'utf8'))
 pluginJson.version = version
 writeFileSync(pluginJsonPath, `${JSON.stringify(pluginJson, null, 2)}\n`)
 process.stderr.write(`sync-versions: plugin.json -> ${version}\n`)
+
+// Sync marketplace.json plugin version
+const marketplacePath = join(ROOT, '.claude-plugin', 'marketplace.json')
+const marketplace = JSON.parse(readFileSync(marketplacePath, 'utf8'))
+for (const plugin of marketplace.plugins) {
+  if (plugin.source?.source === 'npm') {
+    plugin.source.version = version
+  }
+}
+writeFileSync(marketplacePath, `${JSON.stringify(marketplace, null, 2)}\n`)
+process.stderr.write(`sync-versions: marketplace.json -> ${version}\n`)


### PR DESCRIPTION
## Summary
- marketplace.json의 plugin source에 `version` 필드 추가
- sync-versions.ts에서 릴리스 시 marketplace.json 버전도 자동 동기화하도록 수정

## Test plan
- [x] `pnpm run check` 통과 확인
- [x] `npx tsx scripts/sync-versions.ts` 실행 후 marketplace.json 버전 동기화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)